### PR TITLE
Skip render when xrLocateViews returns invalid pose

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -9,7 +9,7 @@ opts = Variables(customs, ARGUMENTS)
 env = DefaultEnvironment()
 
 # Define our parameters
-opts.Add(EnumVariable('platform', "Platform", 'windows', ['linux', 'osx', 'windows']))
+opts.Add(EnumVariable('platform', "Platform", 'windows', ['linux', 'windows']))
 opts.Add(EnumVariable('target', "Compilation target", 'release', ['d', 'debug', 'r', 'release']))
 opts.AddVariables(
     PathVariable('target_path', 'The path where the lib is installed.', 'demo/addons/godot-openxr/bin/'),

--- a/SConstruct
+++ b/SConstruct
@@ -74,8 +74,10 @@ elif env['platform'] == "linux":
 
     if env['target'] in ('debug', 'd'):
         env.Append(CCFLAGS = ['-fPIC', '-ggdb','-O0'])
+        env.Append(CXXFLAGS = ['-fPIC', '-ggdb','-O0'])
     else:
         env.Append(CCFLAGS = ['-fPIC', '-g','-O3'])
+        env.Append(CXXFLAGS = ['-fPIC', '-g','-O3'])
     env.Append(CXXFLAGS = [ '-std=c++0x' ])
     env.Append(LINKFLAGS = [ '-Wl,-R,\'$$ORIGIN\'' ])
 

--- a/src/OS.cpp
+++ b/src/OS.cpp
@@ -4,23 +4,23 @@
 
 #include "OS.h"
 
-OS *OS::singleton = NULL;
+OSNative *OSNative::singleton = NULL;
 
-OS *OS::get_singleton() {
+OSNative *OSNative::get_singleton() {
 	if (singleton == NULL) {
-		singleton = new OS();
+		singleton = new OSNative();
 	}
 	return singleton;
 }
 
-void OS::cleanup_singleton() {
+void OSNative::cleanup_singleton() {
 	if (singleton != NULL) {
 		delete singleton;
 		singleton = NULL;
 	}
 }
 
-OS::OS() {
+OSNative::OSNative() {
 	_os_singleton = api->godot_global_get_singleton((char *)"OS");
 	mb_get_ticks_msec = api->godot_method_bind_get_method("_OS", "get_ticks_msec");
 	mb_get_screen_size = api->godot_method_bind_get_method("_OS", "get_screen_size");
@@ -28,18 +28,18 @@ OS::OS() {
 	mb_get_native_handle = api->godot_method_bind_get_method("_OS", "get_native_handle");
 }
 
-OS::~OS() {
+OSNative::~OSNative() {
 	// nothing to do here
 }
 
-int64_t OS::get_ticks_msec() {
+int64_t OSNative::get_ticks_msec() {
 	if (mb_get_ticks_msec == NULL) {
 		return 0;
 	}
 	return ___godot_icall_int(mb_get_ticks_msec, _os_singleton);
 }
 
-godot_vector2 OS::get_screen_size(const int64_t screen) {
+godot_vector2 OSNative::get_screen_size(const int64_t screen) {
 	if (mb_get_screen_size == NULL) {
 		godot_vector2 empty;
 		api->godot_vector2_new(&empty, 0.0f, 0.0f);
@@ -48,14 +48,14 @@ godot_vector2 OS::get_screen_size(const int64_t screen) {
 	return ___godot_icall_Vector2_int(mb_get_screen_size, _os_singleton, screen);
 }
 
-int64_t OS::get_current_video_driver() {
+int64_t OSNative::get_current_video_driver() {
 	if (mb_get_current_video_driver == NULL) {
 		return 0;
 	}
 	return ___godot_icall_int(mb_get_current_video_driver, _os_singleton);
 }
 
-void *OS::get_native_handle(godot_int p_handle_type) {
+void *OSNative::get_native_handle(godot_int p_handle_type) {
 	if (mb_get_native_handle == NULL) {
 		return 0;
 	}

--- a/src/OS.cpp
+++ b/src/OS.cpp
@@ -48,7 +48,7 @@ godot_vector2 OS::get_screen_size(const int64_t screen) {
 	return ___godot_icall_Vector2_int(mb_get_screen_size, _os_singleton, screen);
 }
 
-godot_int OS::get_current_video_driver() {
+int64_t OS::get_current_video_driver() {
 	if (mb_get_current_video_driver == NULL) {
 		return 0;
 	}

--- a/src/OS.cpp
+++ b/src/OS.cpp
@@ -55,9 +55,9 @@ godot_int OS::get_current_video_driver() {
 	return ___godot_icall_int(mb_get_current_video_driver, _os_singleton);
 }
 
-godot_int OS::get_native_handle(godot_int p_handle_type) {
+void *OS::get_native_handle(godot_int p_handle_type) {
 	if (mb_get_native_handle == NULL) {
 		return 0;
 	}
-	return ___godot_icall_int_int(mb_get_native_handle, _os_singleton, p_handle_type);
+	return (void *)___godot_icall_int_int(mb_get_native_handle, _os_singleton, p_handle_type);
 }

--- a/src/OS.h
+++ b/src/OS.h
@@ -34,7 +34,7 @@ public:
 
 	int64_t get_ticks_msec();
 	godot_vector2 get_screen_size(const int64_t screen = -1);
-	godot_int get_current_video_driver();
+	int64_t get_current_video_driver();
 	void *get_native_handle(godot_int p_handle_type);
 };
 

--- a/src/OS.h
+++ b/src/OS.h
@@ -35,7 +35,7 @@ public:
 	int64_t get_ticks_msec();
 	godot_vector2 get_screen_size(const int64_t screen = -1);
 	godot_int get_current_video_driver();
-	godot_int get_native_handle(godot_int p_handle_type);
+	void *get_native_handle(godot_int p_handle_type);
 };
 
 #endif /* !OS_H */

--- a/src/OS.h
+++ b/src/OS.h
@@ -7,15 +7,15 @@
 
 #include "GodotCalls.h"
 
-class OS {
+class OSNative {
 private:
-	static OS *singleton;
-	godot_object *_os_singleton;
+	static OSNative *singleton;
+	godot_object *_os_singleton = nullptr;
 
-	godot_method_bind *mb_get_ticks_msec;
-	godot_method_bind *mb_get_screen_size;
-	godot_method_bind *mb_get_current_video_driver;
-	godot_method_bind *mb_get_native_handle;
+	godot_method_bind *mb_get_ticks_msec = nullptr;
+	godot_method_bind *mb_get_screen_size = nullptr;
+	godot_method_bind *mb_get_current_video_driver = nullptr;
+	godot_method_bind *mb_get_native_handle = nullptr;
 
 public:
 	enum HandleType {
@@ -26,11 +26,11 @@ public:
 		OPENGL_CONTEXT // HGLRC, X11::GLXContext, NSOpenGLContext*, EGLContext* ...
 	};
 
-	static OS *get_singleton();
+	static OSNative *get_singleton();
 	static void cleanup_singleton();
 
-	OS();
-	~OS();
+	OSNative();
+	~OSNative();
 
 	int64_t get_ticks_msec();
 	godot_vector2 get_screen_size(const int64_t screen = -1);

--- a/src/OpenXRApi.cpp
+++ b/src/OpenXRApi.cpp
@@ -312,7 +312,7 @@ OpenXRApi::OpenXRApi() {
 	// TODO: maybe support xcb separately?
 	// TODO: support vulkan
 
-	OS *os = OS::get_singleton();
+	OSNative *os = OSNative::get_singleton();
 
 	// this will be 0 for GLES3, 1 for GLES2, not sure yet for Vulkan.
 	int video_driver = os->get_current_video_driver();
@@ -323,8 +323,8 @@ OpenXRApi::OpenXRApi() {
 		.next = NULL,
 	};
 
-	graphics_binding_gl.hDC = (HDC)os->get_native_handle(OS::WINDOW_VIEW);
-	graphics_binding_gl.hGLRC = (HGLRC)os->get_native_handle(OS::OPENGL_CONTEXT);
+	graphics_binding_gl.hDC = (HDC)os->get_native_handle(OSNative::WINDOW_VIEW);
+	graphics_binding_gl.hGLRC = (HGLRC)os->get_native_handle(OSNative::OPENGL_CONTEXT);
 
 	if ((graphics_binding_gl.hDC == 0) || (graphics_binding_gl.hGLRC == 0)) {
 		printf("Windows native handle API is missing, please use a newer version of Godot!\n");

--- a/src/OpenXRApi.cpp
+++ b/src/OpenXRApi.cpp
@@ -337,12 +337,17 @@ OpenXRApi::OpenXRApi() {
 		.next = NULL,
 	};
 
-	// TODO: get this from godot engine using get_native_handle
-	graphics_binding_gl.xDisplay = XOpenDisplay(NULL);
-	graphics_binding_gl.glxContext = glXGetCurrentContext();
-	graphics_binding_gl.glxDrawable = glXGetCurrentDrawable();
+	void *display_handle = (void *)os->get_native_handle(OSNative::DISPLAY_HANDLE);
+	void *glxcontext_handle = (void *)os->get_native_handle(OSNative::OPENGL_CONTEXT);
+	void *glxdrawable_handle = (void *)os->get_native_handle(OSNative::WINDOW_HANDLE);
 
-	// init visualid and glxFBConfig ??
+	graphics_binding_gl.xDisplay = (Display *)display_handle;
+	graphics_binding_gl.glxContext = (GLXContext)glxcontext_handle;
+	graphics_binding_gl.glxDrawable = (GLXDrawable)glxdrawable_handle;
+
+	// spec says to use proper values but runtimes don't care
+	graphics_binding_gl.visualid = 0;
+	graphics_binding_gl.glxFBConfig = 0;
 
 	printf("Graphics: Display %p, Context %" PRIxPTR ", Drawable %" PRIxPTR
 		   "\n",

--- a/src/OpenXRApi.cpp
+++ b/src/OpenXRApi.cpp
@@ -1346,6 +1346,10 @@ void OpenXRApi::process_openxr() {
 					}
 
 					XrPath prof = state.interactionProfile;
+					if (prof == XR_NULL_PATH) {
+						printf("No interaction profile for %s\n", i == 0 ? "/user/hand/left" : "/user/hand/right");
+						continue;
+					}
 
 					uint32_t strl;
 					char profile_str[XR_MAX_PATH_LENGTH];

--- a/src/OpenXRApi.h
+++ b/src/OpenXRApi.h
@@ -86,7 +86,7 @@ private:
 	// GLuint depthbuffer;
 
 	XrCompositionLayerProjection *projectionLayer = NULL;
-	XrFrameState frameState;
+	XrFrameState frameState = {};
 	bool running;
 
 	XrSessionState state;

--- a/src/OpenXRApi.h
+++ b/src/OpenXRApi.h
@@ -90,11 +90,10 @@ private:
 	bool running;
 
 	XrSessionState state;
-	bool should_render;
+	bool view_pose_valid = false;
 
 	uint32_t *buffer_index = NULL;
 
-	bool views_located = false;
 	XrView *views = NULL;
 	XrCompositionLayerProjectionView *projection_views = NULL;
 


### PR DESCRIPTION
Invalid pose means that the view pose quaternion may not be a valid (normalized) quaternion, which means xrEndFrame() will fail when supplied our projection layer with this view pose.