### PR TITLE
use get_native_handle() for xlib on linux 

### DIFF
--- a/src/OpenXRApi.cpp
+++ b/src/OpenXRApi.cpp
@@ -345,6 +345,19 @@ OpenXRApi::OpenXRApi() {
 	graphics_binding_gl.glxContext = (GLXContext)glxcontext_handle;
 	graphics_binding_gl.glxDrawable = (GLXDrawable)glxdrawable_handle;
 
+	if (graphics_binding_gl.xDisplay == NULL) {
+		printf("Failed to get xDisplay from Godot, using XOpenDisplay(NULL)\n");
+		graphics_binding_gl.xDisplay = XOpenDisplay(NULL);
+	}
+	if (graphics_binding_gl.glxContext == NULL) {
+		printf("Failed to get glxContext from Godot, using glXGetCurrentContext()\n");
+		graphics_binding_gl.glxContext = glXGetCurrentContext();
+	}
+	if (graphics_binding_gl.glxDrawable == 0) {
+		printf("Failed to get glxDrawable from Godot, using glXGetCurrentDrawable()\n");
+		graphics_binding_gl.glxDrawable = glXGetCurrentDrawable();
+	}
+
 	// spec says to use proper values but runtimes don't care
 	graphics_binding_gl.visualid = 0;
 	graphics_binding_gl.glxFBConfig = 0;


### PR DESCRIPTION
On Linux the `get_native_handle()` function in the godot_openxr plugin failed completely and my debugger linked my only to the prototype in godot's OS class https://github.com/godotengine/godot/blob/150f9ce807e7b9be45bf8c030faa80510aea8407/core/os/os.h#L255. No idea what went wrong there but renaming the class in godot_openxr fixed it d7c04f7.

