### PR TITLE
only enable hand tracking ext if supported

### DIFF
--- a/src/OpenXRApi.h
+++ b/src/OpenXRApi.h
@@ -80,6 +80,7 @@ public:
 private:
 	static OpenXRApi *singleton;
 	bool successful_init;
+	bool hand_tracking_ext_supported = false;
 	bool hand_tracking_supported = false;
 	int use_count;
 


### PR DESCRIPTION
Make the MeshInstances on the HandControllers visible in the editor to see blocks for hands.

fixes #26

This PR is not actually tested on a runtime without hand tracking ext support.