### PR TITLE
scons: Don't set std=c++17 for CCFLAGS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -46,9 +46,11 @@ if env['platform'] == "windows":
         env['CC'] = 'clang'
 
         if env['target'] in ('debug', 'd'):
-            env.Append(CCFLAGS = ['-fPIC', '-g3','-Og', '-std=c++17'])
+            env.Append(CCFLAGS = ['-fPIC', '-g3','-Og'])
+            env.Append(CXXFLAGS = ['-fPIC', '-g3','-Og', '-std=c++17'])
         else:
-            env.Append(CCFLAGS = ['-fPIC','-O3', '-std=c++17'])
+            env.Append(CCFLAGS = ['-fPIC','-O3'])
+            env.Append(CXXFLAGS = ['-fPIC','-O3', '-std=c++17'])
     else:
         # This makes sure to keep the session environment variables on windows,
         # that way you can run scons in a vs 2017 prompt and it will find all the required tools


### PR DESCRIPTION
Clang 6.0:

clang -o glad/glad.os -c -fPIC -O3 -std=c++17 -fPIC -Iglad -I. -Isrc -Igodot-cpp/godot_headers -Igodot-cpp/include -Igodot-cpp/include/core -Igodot-cpp/include/gen -Iopenxr_loader_windows/1.0.12/include glad/glad.c
error: invalid argument '-std=c++17' not allowed with 'C'