### PR TITLE
Adding a runtime selection dropdown into the editor

### DIFF
--- a/demo/addons/godot-openxr/editor/OpenXRRunSelect.gd
+++ b/demo/addons/godot-openxr/editor/OpenXRRunSelect.gd
@@ -1,0 +1,76 @@
+tool
+extends OptionButton
+
+var available_runtimes : Array = Array()
+onready var platform = OS.get_name()
+
+var home_folder = ''
+
+func _parse_path(p_path):
+	# we might want to add more stuff here at some point
+	p_path = p_path.replace("~", home_folder)
+	return p_path
+
+func _update_tooltip():
+	if selected > 0:
+		var i = get_item_id(selected)
+		hint_tooltip = _parse_path(available_runtimes[i]["path"])
+	else:
+		hint_tooltip = "Select the OpenXR runtime test your project with"
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	var current_runtime = 0
+
+	# Parse the users home folder
+	home_folder = OS.get_environment("HOME")
+	if home_folder == '':
+		home_folder = OS.get_environment("HOMEDRIVE") +  OS.get_environment("HOMEPATH")
+
+	# read our json file, may have entries for multiple platforms, we'll filter them later
+	var f = File.new()
+	if (f.open("res://addons/godot-openxr/runtimes.json", File.READ)) == OK:
+		var json = JSON.parse(f.get_as_text())
+		available_runtimes = json.result as Array
+		f.close()
+
+	# check what our current value is
+	var current_path = OS.get_environment("XR_RUNTIME_JSON")
+
+	if available_runtimes.size() > 0:
+		# reset our dropdown if applicable
+		clear()
+		add_item("Default", -1)
+
+		# check which runtimes are actually available
+		var dir = Directory.new()
+		var index = 0
+		for i in available_runtimes.size():
+			var runtime = available_runtimes[i]
+			var path = _parse_path(runtime["path"])
+			if dir.file_exists(path):
+				add_item(runtime["name"], i)
+				index = index + 1
+				if path == current_path:
+					current_runtime = index
+
+		selected = current_runtime
+		_update_tooltip()
+
+		visible = true
+	else:
+		# I guess nothing supported on this platform
+		visible = false
+
+func _on_OpenXRRunSelect_item_selected(index):
+	# this need latest 3.2.4
+	if index == 0:
+		print("Returning to default")
+		OS.set_environment("XR_RUNTIME_JSON", "")
+	else:
+		var i = get_item_id(index)
+		var runtime = _parse_path(available_runtimes[i]["path"])
+		print("Switching to " + runtime)
+		OS.set_environment("XR_RUNTIME_JSON", runtime)
+
+	_update_tooltip()

--- a/demo/addons/godot-openxr/editor/OpenXRRunSelect.tscn
+++ b/demo/addons/godot-openxr/editor/OpenXRRunSelect.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot-openxr/editor/OpenXRRunSelect.gd" type="Script" id=1]
+
+[node name="OpenXRRunSelect" type="OptionButton"]
+text = "Default"
+items = [ "Default", null, false, 0, null, "SteamVR", null, false, 2, null, "Oculus", null, false, 3, null, "Microsoft MR", null, false, 4, null ]
+selected = 0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[connection signal="item_selected" from="." to="." method="_on_OpenXRRunSelect_item_selected"]

--- a/demo/addons/godot-openxr/plugin.cfg
+++ b/demo/addons/godot-openxr/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Godot OpenXR"
+description="Godot OpenXR plugin"
+author="Christoph Haag and Bastiaan Olij"
+version="1.0.1"
+script="plugin.gd"

--- a/demo/addons/godot-openxr/plugin.gd
+++ b/demo/addons/godot-openxr/plugin.gd
@@ -1,0 +1,14 @@
+tool
+extends EditorPlugin
+
+var openxr_run_select = null
+
+func _enter_tree():
+	openxr_run_select = preload("res://addons/godot-openxr/editor/OpenXRRunSelect.tscn").instance()
+	add_control_to_container(CONTAINER_TOOLBAR, openxr_run_select)
+
+func _exit_tree():
+	if openxr_run_select:
+		remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, openxr_run_select)
+		openxr_run_select.queue_free()
+		openxr_run_select = null

--- a/demo/addons/godot-openxr/runtimes.json
+++ b/demo/addons/godot-openxr/runtimes.json
@@ -1,0 +1,22 @@
+[
+    {
+        "name": "Monado",
+        "path": "/usr/share/openxr/1/openxr_monado.json"
+    },
+    {
+        "name": "SteamVR",
+        "path": "~/.steam/steam/steamapps/common/SteamVR/steamxr_linux64.json"
+    },
+    {
+        "name": "SteamVR",
+        "path": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\steamxr_win64.json"
+    },
+    {
+        "name": "Oculus",
+        "path": "C:\\Program Files\\Oculus\\Support\\oculus-runtime\\oculus_openxr_64.json"
+    },
+    {
+        "name": "Microsoft MR",
+        "path": "C:\\WINDOWS\\system32\\MixedRealityRuntime.json"
+    }
+]

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -22,6 +22,10 @@ config/icon="res://icon.png"
 
 window/vsync/use_vsync=false
 
+[editor_plugins]
+
+enabled=PoolStringArray( "res://addons/godot-openxr/plugin.cfg" )
+
 [gdnative]
 
 singletons=[ "res://addons/godot-openxr/godot_openxr.gdnlib" ]


### PR DESCRIPTION
Adding a dropdown (windows only) to the editor that allows us to select from different (known) runtimes:
![image](https://user-images.githubusercontent.com/1945449/108299445-8dcd5300-71f2-11eb-8059-fd51f7075c57.png)

The known runtimes are stored in `runtimes.json` in our addons folder so we can easily add more entries. On reading the JSON we will check if the paths to the runtime files exist and only offer those we find. We'll probably need to make it smarter to check the same path on different drives in case the user has decided to install Oculus/Steam on a D: or E: drive or something but that is for an enhancement PR.

If the current runtime is not found in the list, it is added (in editor only, the `runtimes.json` is not altered). 