### PR TITLE
update godot requirement to 3.3 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Versions
 
-Requires Godot 3.2.4 (currently in beta), does not (yet) work with Godot 4.
+Requires Godot 3.3, does not (yet) work with Godot 4.
 
 Note: The godot engine (the full engine, not this plugin) must be compiled in release_debug mode, i.e. with
 


### PR DESCRIPTION
Probably not many people need to use a 3.2.4 beta and miss the info that it can work on those too.