### PR TITLE
Updated contributors, it was still the original one from OpenHMD

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,11 +1,10 @@
 Contributors
 ============
 
-This plugin has mostly been developed by [Christoph Haag](https://github.com/ChristophHaag/).
+This plugin has mostly been developed by:
+- [Christoph Haag](https://github.com/ChristophHaag) (original plugin and Linux support)
+- [Bastiaan Olij](https://github.com/BastiaanOlij) (Windows support).
 
 Other people who have helped out by submitting fixes, enhancements, etc are:
-- [Bastiaan Olij](https://github.com/BastiaanOlij)
-- [Joey Ferwerda](https://github.com/TheOnlyJoey)
-- [Philipp Zabel](https://github.com/pH5)
-- [Douglas Xie](https://github.com/Douglas-3Glasses)
 - [Aaron Franke](https://github.com/aaronfranke)
+- [Benedikt](https://github.com/beniwtv)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 Bastiaan Olij, Christoph Haag and contributors
+Copyright (c) 2018-2021 Bastiaan Olij, Christoph Haag and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We still have the original contributors file from the OpenHMD plugin. I don't think the current plugin has much in common with that anymore :) 

Updated it to reflect who have been contributing here.

That said, Christoph let me know if I should leave some of the names in there if they contributed to the original plugin before we moved it here. 

