### PR TITLE
Fix re-init of action sets when headset refocusses

### DIFF
--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -1,6 +1,10 @@
 Changes to the Godot OpenXR asset
 =================================
 
+1.0.1
+-------------------
+- Fix crash issue on Oculus Link when taking headset off and putting it back on.
+
 1.0.0
 -------------------
 - Original implementation

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -1092,6 +1092,13 @@ bool OpenXRApi::initialiseSwapChains() {
 }
 
 bool OpenXRApi::initialiseActionSets() {
+	if (actionset_status != ACTION_SET_UNINITIALISED) {
+		return actionset_status == ACTION_SET_INITIALISED;
+	}
+
+	// assume failure until we succeed..
+	actionset_status = ACTION_SET_FAILED;
+
 	Godot::print("OpenXR initialiseActionSets");
 
 	parse_action_sets(action_sets_json);
@@ -1128,6 +1135,8 @@ bool OpenXRApi::initialiseActionSets() {
 		}
 	}
 
+	// yeah!
+	actionset_status = ACTION_SET_INITIALISED;
 	return true;
 }
 

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -139,9 +139,16 @@ public:
 	};
 
 private:
+	enum ActionSetStatus {
+		ACTION_SET_UNINITIALISED,
+		ACTION_SET_INITIALISED,
+		ACTION_SET_FAILED
+	};
+
 	static OpenXRApi *singleton;
 	bool initialised = false;
 	bool running = false;
+	ActionSetStatus actionset_status = ACTION_SET_UNINITIALISED;
 	int use_count = 1;
 
 	// extensions


### PR DESCRIPTION
Finally got around to testing OpenXR with Oculus Link and indeed got things to crash when you take off the headset and put it back on.

Oculus Link gets an `XR_SESSION_STATE_FOCUSED` every time you put the headset back on and we were initializing the action set at this point in time. As it already was initialized the second initialization failed.

I'm keeping a status now to prevent double init. There is probably more to this in the future if we ever have a reason for re-initializing the action set but that's for another day.