### PR TITLE
Add motion range support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -74,6 +74,9 @@ elif env['platform'] == "linux":
     target_path += "linux/"
     godot_cpp_library += '.linux'
 
+    # make sure we have access to the correct headers, cheating here a little.
+    openxr_include_path += "openxr_loader_windows/1.0.16/include/"
+
     # note, on linux the OpenXR SDK is installed in /usr and should be accessible
     if env['use_llvm']:
         env['CXX'] = 'clang++'

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -114,6 +114,7 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 1, -0.5 )
 
 [node name="Right_hand" parent="FPSController" instance=ExtResource( 5 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, -0.5 )
+motion_range = 0
 
 [node name="Table" parent="." instance=ExtResource( 3 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -6 )

--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -3,7 +3,8 @@ Changes to the Godot OpenXR asset
 
 1.0.1
 -------------------
-- Fix crash issue on Oculus Link when taking headset off and putting it back on.
+- Fix crash issue on Oculus Link when taking headset off and putting it back on
+- Add support for finger tracking motion range
 
 1.0.0
 -------------------

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -34,7 +34,7 @@ singletons=[ "res://addons/godot-openxr/godot_openxr.gdnlib" ]
 
 Fire={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
  ]
 }

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -58,9 +58,12 @@ class OpenXRApi;
 #include "openxr/actions/actionset.h"
 
 // TODO move hand tracker logic into it's own source files, I'll do a separate PR for that in due time.
+#define MAX_TRACKED_HANDS 2
+
 class HandTracker {
 public:
 	bool is_initialised = false;
+	XrHandJointsMotionRangeEXT motion_range = XR_HAND_JOINTS_MOTION_RANGE_UNOBSTRUCTED_EXT;
 
 	XrHandTrackerEXT hand_tracker;
 	XrHandJointLocationEXT joint_locations[XR_HAND_JOINT_COUNT_EXT];
@@ -153,6 +156,7 @@ private:
 
 	// extensions
 	bool hand_tracking_ext = false;
+	bool hand_motion_range_ext = false;
 	bool monado_stick_on_ball_ext = false;
 	bool hand_tracking_supported = false;
 
@@ -184,7 +188,7 @@ private:
 	bool view_pose_valid = false;
 	bool head_pose_valid = false;
 
-	HandTracker hand_trackers[2]; // Fixed for left and right hand
+	HandTracker hand_trackers[MAX_TRACKED_HANDS]; // Fixed for left and right hand
 
 	// config
 	/*
@@ -257,7 +261,10 @@ public:
 		return false;
 	};
 
-	const HandTracker *get_hand_tracker(int p_hand) { return &hand_trackers[p_hand]; };
+	// hand tracking
+	const HandTracker *get_hand_tracker(uint32_t p_hand) const;
+	XrHandJointsMotionRangeEXT get_motion_range(uint32_t p_hand) const;
+	void set_motion_range(uint32_t p_hand, XrHandJointsMotionRangeEXT p_motion_range);
 
 	// config
 	XrFormFactor get_form_factor() const;

--- a/src/openxr/OpenXRHand.h
+++ b/src/openxr/OpenXRHand.h
@@ -15,8 +15,10 @@ class OpenXRHand : public Spatial {
 private:
 	OpenXRApi *openxr_api;
 	int hand;
+	int motion_range;
 
 	Spatial *joints[XR_HAND_JOINT_COUNT_EXT];
+	void _set_motion_range();
 
 public:
 	static void _register_methods();
@@ -32,6 +34,9 @@ public:
 
 	int get_hand() const;
 	void set_hand(int p_hand);
+
+	int get_motion_range() const;
+	void set_motion_range(int p_motion_range);
 };
 } // namespace godot
 

--- a/src/openxr/OpenXRSkeleton.h
+++ b/src/openxr/OpenXRSkeleton.h
@@ -15,8 +15,10 @@ class OpenXRSkeleton : public Skeleton {
 private:
 	OpenXRApi *openxr_api;
 	int hand;
+	int motion_range;
 
 	int64_t bones[XR_HAND_JOINT_COUNT_EXT];
+	void _set_motion_range();
 
 public:
 	static void _register_methods();
@@ -30,6 +32,9 @@ public:
 
 	int get_hand() const;
 	void set_hand(int p_hand);
+
+	int get_motion_range() const;
+	void set_motion_range(int p_motion_range);
 };
 } // namespace godot
 


### PR DESCRIPTION
This implements the motion range extension provided this is supported by the OpenXR runtime.

This allows you to toggle the range for finger tracking:
- Unobstructed will make a closed first when the user grabs the controller (default)
- Conform to controller will limit the range of the fingers so it grabs the controller 
These are the only two models currently supported by OpenXR but more will likely be added in the future. 

You can switch between the modes at runtime, so you could use unobstructed and not show the controller, then when something is picked up you can go back to the conform to controller mode. 

Note that there is only one setting tracked per hand so if you use multiple Hand/Skeleton nodes for each hand the last one wins. It's assumed you don't represent a hand more then once. 

