### PR TITLE
Reworking lifecycle

### DIFF
--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -151,7 +151,6 @@ private:
 	static OpenXRApi *singleton;
 	bool initialised = false;
 	bool running = false;
-	ActionSetStatus actionset_status = ACTION_SET_UNINITIALISED;
 	int use_count = 1;
 
 	// extensions
@@ -160,6 +159,7 @@ private:
 	bool monado_stick_on_ball_ext = false;
 	bool hand_tracking_supported = false;
 
+	XrViewConfigurationType view_config_type = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
 	XrInstance instance = XR_NULL_HANDLE;
 	XrSystemId systemId;
 	XrSession session = XR_NULL_HANDLE;
@@ -213,13 +213,30 @@ private:
 	bool isExtensionSupported(const char *extensionName, XrExtensionProperties *instanceExtensionProperties, uint32_t instanceExtensionCount);
 	bool isViewConfigSupported(XrViewConfigurationType type, XrSystemId systemId);
 	bool isReferenceSpaceSupported(XrReferenceSpaceType type);
+
 	bool initialiseInstance();
 	bool initialiseExtensions();
 	bool initialiseSession();
 	bool initialiseSpaces();
+	void cleanupSpaces();
 	bool initialiseSwapChains();
-	bool initialiseActionSets();
+	void cleanupSwapChains();
 	bool initialiseHandTracking();
+
+	bool loadActionSets();
+	bool bindActionSets();
+	void unbindActionSets();
+	void cleanupActionSets();
+
+	bool on_state_idle();
+	bool on_state_ready();
+	bool on_state_synchronized();
+	bool on_state_visible();
+	bool on_state_focused();
+	bool on_state_stopping();
+	bool on_state_loss_pending();
+	bool on_state_existing();
+
 	bool check_graphics_requirements_gl(XrSystemId system_id);
 	XrResult acquire_image(int eye);
 	void update_actions();
@@ -239,6 +256,7 @@ public:
 	bool is_initialised();
 	bool initialize();
 	void uninitialize();
+	bool is_running();
 
 	XrInstance get_instance() { return instance; };
 	XrSession get_session() { return session; };

--- a/src/openxr/actions/action.cpp
+++ b/src/openxr/actions/action.cpp
@@ -91,7 +91,10 @@ XrAction Action::get_action() const {
 }
 
 bool Action::get_as_bool(XrPath p_path) {
-	if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
+	if (!xr_api->is_running()) {
+		// not running
+		return false;
+	} else if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
 		// not initialised
 		return false;
 	} else if (type != XR_ACTION_TYPE_BOOLEAN_INPUT) {
@@ -120,7 +123,10 @@ bool Action::get_as_bool(XrPath p_path) {
 }
 
 float Action::get_as_float(XrPath p_path) {
-	if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
+	if (!xr_api->is_running()) {
+		// not running
+		return 0.0;
+	} else if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
 		// not initialised
 		return 0.0;
 	} else if (type != XR_ACTION_TYPE_FLOAT_INPUT) {
@@ -149,7 +155,10 @@ float Action::get_as_float(XrPath p_path) {
 }
 
 Vector2 Action::get_as_vector(XrPath p_path) {
-	if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
+	if (!xr_api->is_running()) {
+		// not running
+		return Vector2();
+	} else if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
 		// not initialised
 		return Vector2();
 	} else if (type != XR_ACTION_TYPE_VECTOR2F_INPUT) {
@@ -178,7 +187,10 @@ Vector2 Action::get_as_vector(XrPath p_path) {
 }
 
 bool Action::is_pose_active(XrPath p_path) {
-	if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
+	if (!xr_api->is_running()) {
+		// not running
+		return false;
+	} else if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
 		// not initialised
 		Godot::print("Pose not initialised");
 		return false;
@@ -207,7 +219,10 @@ bool Action::is_pose_active(XrPath p_path) {
 }
 
 Transform Action::get_as_pose(XrPath p_path, float p_world_scale) {
-	if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
+	if (!xr_api->is_running()) {
+		// not running
+		return Transform();
+	} else if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
 		// not initialised or setup fully
 		return Transform();
 	} else if (type != XR_ACTION_TYPE_POSE_INPUT) {
@@ -262,7 +277,10 @@ Transform Action::get_as_pose(XrPath p_path, float p_world_scale) {
 }
 
 void Action::do_haptic_pulse(const XrPath p_path, XrDuration p_duration, float p_frequency, float p_amplitude) {
-	if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
+	if (!xr_api->is_running()) {
+		// not running
+		return;
+	} else if (handle == XR_NULL_HANDLE || p_path == XR_NULL_PATH) {
 		// not initialised or setup fully
 		return;
 	} else if (type != XR_ACTION_TYPE_VIBRATION_OUTPUT) {


### PR DESCRIPTION
Just a quick and dirty first pass so far but working on moving parts of the initialisation of the plugin to the proper timing as far as the OpenXR lifecycle is concerned.

Right now we do almost all initialisation right away but according to the documentation:
https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#session

We're supposed to wait on state changes once the session is created before proceeding. 

This should also enable us to react properly on the OpenXR runtime requesting a session to be ended and on quitting the application.