### PR TITLE
Fix folder structure of godot_openxr.zip created by Github actions

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -109,11 +109,12 @@ jobs:
         uses: actions/download-artifact@v2
       - name: Copy files to destination
         run: |
-          mkdir addons
-          cp -r godot_openxr/demo/addons/godot-openxr addons
-          cp build-files-linux/libgodot_openxr.so addons/godot-openxr/bin/linux/libgodot_openxr.so
-          cp build-files-windows/demo/addons/godot-openxr/bin/win64/libgodot_openxr.dll addons/godot-openxr/bin/win64/libgodot_openxr.dll
-          cp build-files-windows/openxr_loader_windows/1.0.16/x64/bin/openxr_loader.dll addons/godot-openxr/bin/win64/openxr_loader.dll
+          mkdir godot_openxr_plugin
+          mkdir godot_openxr_plugin/addons
+          cp -r godot_openxr/demo/addons/godot-openxr godot_openxr_plugin/addons
+          cp build-files-linux/libgodot_openxr.so godot_openxr_plugin/addons/godot-openxr/bin/linux/libgodot_openxr.so
+          cp build-files-windows/demo/addons/godot-openxr/bin/win64/libgodot_openxr.dll godot_openxr_plugin/addons/godot-openxr/bin/win64/libgodot_openxr.dll
+          cp build-files-windows/openxr_loader_windows/1.0.16/x64/bin/openxr_loader.dll godot_openxr_plugin/addons/godot-openxr/bin/win64/openxr_loader.dll
       - name: Calculate GIT short ref
         run: |
           cd godot_openxr
@@ -130,8 +131,9 @@ jobs:
           rm -rf build-files-windows
           rm -rf godot_openxr
           rm -rf .git
-          rm addons/godot-openxr/bin/win64/.gitignore
-          rm addons/godot-openxr/bin/linux/.gitignore
+          rm godot_openxr_plugin/addons/godot-openxr/bin/win64/.gitignore
+          rm godot_openxr_plugin/addons/godot-openxr/bin/linux/.gitignore
+          mv godot_openxr_plugin godot_openxr_${{ env.GITHUB_SHA_SHORT }}
       - name: Zip asset
         run: |
           zip -qq -r godot-openxr.zip .

--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -1,6 +1,10 @@
 Changes to the Godot OpenXR asset
 =================================
 
+1.0.2
+-------------------
+- Fix folder structure of godot_openxr.zip created by Github actions
+
 1.0.1
 -------------------
 - Fix crash issue on Oculus Link when taking headset off and putting it back on


### PR DESCRIPTION
The asset library bases deployment on zip files produced from a github repository which start with a folder name based on the repos name. 
This causes the `addons` folder in the zipfile to be ignored, we need to add a parent folder