### PR TITLE
Ignore Android folder in formatting checks

### DIFF
--- a/.github/workflows/scripts/clang_format.sh
+++ b/.github/workflows/scripts/clang_format.sh
@@ -24,6 +24,8 @@ while IFS= read -rd '' f; do
         continue
     elif [[ "$f" == "build"* ]]; then
         continue
+    elif [[ "$f" == "android"* ]]; then
+        continue
     elif [[ "$f" == ".github"* ]]; then
         continue
     fi

--- a/.github/workflows/scripts/file_format.sh
+++ b/.github/workflows/scripts/file_format.sh
@@ -27,6 +27,8 @@ while IFS= read -rd '' f; do
         continue
     elif [[ "$f" == "build"* ]]; then
         continue
+    elif [[ "$f" == "android"* ]]; then
+        continue
     elif [[ "$f" == "api.json" ]]; then
         continue
     fi


### PR DESCRIPTION
Ignore formatting issues in our android files, these are all support files we don't have formatting rules for (yet)