### PR TITLE
Setting color space on quest

### DIFF
--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -168,6 +168,7 @@ private:
 	bool hand_motion_range_ext = false;
 	bool monado_stick_on_ball_ext = false;
 	bool hand_tracking_supported = false;
+	bool color_space_ext = false;
 
 	XrViewConfigurationType view_config_type = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
 	XrInstance instance = XR_NULL_HANDLE;


### PR DESCRIPTION
Working on #67 for the quest.

In GLES3 mode, provided we adhere to setting `keep_3d_linear` to true when requested, everything looks fine.
But as in GLES2 mode everything renders in sRGB color space and OpenXR seems to expect a linear color space image, we double our linear->sRGB color correction.

According to the specs Facebook Reality Labs as implemented the `xrSetColorSpaceFB` extension so we can let it we're supplying an sRGB image and this PR attempts to implement this.

So far it does not seem to have any effect.