### PR TITLE
Fix occurrence of infinity transform from pose.

### DIFF
--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -1,6 +1,10 @@
 Changes to the Godot OpenXR asset
 =================================
 
+1.0.4
+-------------------
+- Fix occurrence of invalid transform from pose.
+
 1.0.3
 -------------------
 - Copy loader dll in place when compiling

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -2585,7 +2585,12 @@ void OpenXRApi::process_openxr() {
 
 Transform OpenXRApi::transform_from_pose(const XrPosef &p_pose, float p_world_scale) {
 	Quat q(p_pose.orientation.x, p_pose.orientation.y, p_pose.orientation.z, p_pose.orientation.w);
-	Basis basis(q);
+	Basis basis;
+	if (q.is_normalized()) {
+		basis = Basis(q);
+	} else {
+		basis = Basis(Quat(Vector3(1, 0, 0), 0));
+	}
 	Vector3 origin(p_pose.position.x * p_world_scale, p_pose.position.y * p_world_scale, p_pose.position.z * p_world_scale);
 
 	return Transform(basis, origin);


### PR DESCRIPTION
OpenXR may give a zero length quaternion at initialization causing a
transform with inf values, resulting in a slew of assertion errors from
`VisualServer.instance_set_transform` if a VisualInstance happens to be
a child of OpenXRHand, OpenXRPose or OpenXRSkeleton.

The OpenXR specification states that the XrQuaterionf should be of unit
length, so I figured `is_normalized` is a good health check.