### PR TITLE
Validate space locations in OpenXRSkeleton and OpenXRPose.

### DIFF
--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -4,6 +4,7 @@ Changes to the Godot OpenXR asset
 1.1.0
 -------------------
 - Implemented Android build (currently using Oculus loader, Quest support only)
+- Fix invalid transforms generated from invalid space locations when using OpenXRSkeleton or OpenXRPose.
 
 1.0.3
 -------------------

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -2742,3 +2742,26 @@ Transform OpenXRApi::transform_from_pose(const XrPosef &p_pose, float p_world_sc
 
 	return Transform(basis, origin);
 }
+
+template <typename T>
+Transform _transform_from_space_location(OpenXRApi &api, const T &p_location, float p_world_scale) {
+	Basis basis;
+	Vector3 origin;
+	const auto &pose = p_location.pose;
+	if (p_location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) {
+		Quat q(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
+		basis = Basis(q);
+	}
+	if (p_location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) {
+		origin = Vector3(pose.position.x, pose.position.y, pose.position.z) * p_world_scale;
+	}
+	return Transform(basis, origin);
+}
+
+Transform OpenXRApi::transform_from_space_location(const XrSpaceLocation &p_location, float p_world_scale) {
+	return _transform_from_space_location(*this, p_location, p_world_scale);
+}
+
+Transform OpenXRApi::transform_from_space_location(const XrHandJointLocationEXT &p_location, float p_world_scale) {
+	return _transform_from_space_location(*this, p_location, p_world_scale);
+}

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -350,6 +350,10 @@ public:
 
 	// helper method to get a transform from an openxr pose
 	godot::Transform transform_from_pose(const XrPosef &p_pose, float p_world_scale);
+
+	// helper method to get a valid transform from an openxr space location
+	godot::Transform transform_from_space_location(const XrSpaceLocation &p_location, float p_world_scale);
+	godot::Transform transform_from_space_location(const XrHandJointLocationEXT &p_location, float p_world_scale);
 };
 
 #endif /* !OPENXR_API_H */

--- a/src/openxr/OpenXRHand.cpp
+++ b/src/openxr/OpenXRHand.cpp
@@ -129,15 +129,7 @@ void OpenXRHand::_physics_process(float delta) {
 
 	if (hand_tracker->is_initialised && hand_tracker->locations.isActive) {
 		for (int i = 0; i < XR_HAND_JOINT_COUNT_EXT; i++) {
-			const XrPosef &pose = hand_tracker->joint_locations[i].pose;
-			XrSpaceLocationFlags flags = hand_tracker->joint_locations[i].locationFlags;
-			Transform t;
-
-			if ((flags & (XR_SPACE_LOCATION_ORIENTATION_VALID_BIT + XR_SPACE_LOCATION_POSITION_VALID_BIT)) == (XR_SPACE_LOCATION_ORIENTATION_VALID_BIT + XR_SPACE_LOCATION_POSITION_VALID_BIT)) {
-				// only use if valid
-				t = openxr_api->transform_from_pose(pose, ws);
-			}
-
+			Transform t = openxr_api->transform_from_space_location(hand_tracker->joint_locations[i], ws);
 			// store the inverse to make live easier later on
 			inv_transforms[i] = t.inverse();
 

--- a/src/openxr/OpenXRPose.cpp
+++ b/src/openxr/OpenXRPose.cpp
@@ -132,12 +132,10 @@ void OpenXRPose::_physics_process(float delta) {
 	if (action == "SkeletonBase") {
 		if (path == "/user/hand/left") {
 			const HandTracker *hand_tracker = openxr_api->get_hand_tracker(0);
-			const XrPosef &pose = hand_tracker->joint_locations[XR_HAND_JOINT_PALM_EXT].pose;
-			set_transform(reference_frame * openxr_api->transform_from_pose(pose, ws));
+			set_transform(reference_frame * openxr_api->transform_from_space_location(hand_tracker->joint_locations[XR_HAND_JOINT_PALM_EXT], ws));
 		} else if (path == "/user/hand/right") {
 			const HandTracker *hand_tracker = openxr_api->get_hand_tracker(1);
-			const XrPosef &pose = hand_tracker->joint_locations[XR_HAND_JOINT_PALM_EXT].pose;
-			set_transform(reference_frame * openxr_api->transform_from_pose(pose, ws));
+			set_transform(reference_frame * openxr_api->transform_from_space_location(hand_tracker->joint_locations[XR_HAND_JOINT_PALM_EXT], ws));
 		}
 	} else if (check_action_and_path()) {
 		set_transform(reference_frame * _action->get_as_pose(_path, ws));

--- a/src/openxr/OpenXRSkeleton.cpp
+++ b/src/openxr/OpenXRSkeleton.cpp
@@ -105,8 +105,7 @@ void OpenXRSkeleton::_physics_process(float delta) {
 	if (hand_tracker->is_initialised && hand_tracker->locations.isActive) {
 		// get our transforms
 		for (int i = 0; i < XR_HAND_JOINT_COUNT_EXT; i++) {
-			const XrPosef &pose = hand_tracker->joint_locations[i].pose;
-			transforms[i] = openxr_api->transform_from_pose(pose, ws);
+			transforms[i] = openxr_api->transform_from_space_location(hand_tracker->joint_locations[i], ws);
 			inv_transforms[i] = transforms[i].inverse();
 		}
 


### PR DESCRIPTION
OpenXR may give a zero length quaternion at initialization causing a
transform with inf values, resulting in a slew of assertion errors from
VisualServer.instance_set_transform if a VisualInstance happens to be
a child of OpenXRPose or OpenXRSkeleton.

This is a more rigorous fix than the one I first proposed: https://github.com/GodotVR/godot_openxr/pull/79