### PR TITLE
Move GDNative classes into their own subfolder

### DIFF
--- a/src/gdclasses/OpenXRConfig.cpp
+++ b/src/gdclasses/OpenXRConfig.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////
 // Our OpenXR config GDNative object
 
-#include "OpenXRConfig.h"
+#include "gdclasses/OpenXRConfig.h"
 #include <Dictionary.hpp>
 #include <GlobalConstants.hpp>
 

--- a/src/gdclasses/OpenXRConfig.h
+++ b/src/gdclasses/OpenXRConfig.h
@@ -4,7 +4,7 @@
 #ifndef OPENXR_CONFIG_H
 #define OPENXR_CONFIG_H
 
-#include "OpenXRApi.h"
+#include "openxr/OpenXRApi.h"
 #include <Node.hpp>
 
 namespace godot {

--- a/src/gdclasses/OpenXRHand.cpp
+++ b/src/gdclasses/OpenXRHand.cpp
@@ -3,7 +3,7 @@
 
 #include <ARVRServer.hpp>
 
-#include "OpenXRHand.h"
+#include "gdclasses/OpenXRHand.h"
 
 using namespace godot;
 

--- a/src/gdclasses/OpenXRHand.h
+++ b/src/gdclasses/OpenXRHand.h
@@ -4,7 +4,7 @@
 #ifndef OPENXR_HAND_H
 #define OPENXR_HAND_H
 
-#include "OpenXRApi.h"
+#include "openxr/OpenXRApi.h"
 #include <Ref.hpp>
 #include <Spatial.hpp>
 

--- a/src/gdclasses/OpenXRPose.cpp
+++ b/src/gdclasses/OpenXRPose.cpp
@@ -3,7 +3,7 @@
 
 #include <ARVRServer.hpp>
 
-#include "OpenXRPose.h"
+#include "gdclasses/OpenXRPose.h"
 
 using namespace godot;
 

--- a/src/gdclasses/OpenXRPose.h
+++ b/src/gdclasses/OpenXRPose.h
@@ -4,7 +4,7 @@
 #ifndef OPENXR_POSE_H
 #define OPENXR_POSE_H
 
-#include "OpenXRApi.h"
+#include "openxr/OpenXRApi.h"
 #include <Spatial.hpp>
 
 namespace godot {

--- a/src/gdclasses/OpenXRSkeleton.cpp
+++ b/src/gdclasses/OpenXRSkeleton.cpp
@@ -3,7 +3,7 @@
 
 #include <ARVRServer.hpp>
 
-#include "OpenXRSkeleton.h"
+#include "gdclasses/OpenXRSkeleton.h"
 
 using namespace godot;
 

--- a/src/gdclasses/OpenXRSkeleton.h
+++ b/src/gdclasses/OpenXRSkeleton.h
@@ -4,7 +4,7 @@
 #ifndef OPENXR_SKELETON_H
 #define OPENXR_SKELETON_H
 
-#include "OpenXRApi.h"
+#include "openxr/OpenXRApi.h"
 #include <Ref.hpp>
 #include <Skeleton.hpp>
 

--- a/src/gdclasses/XRInterfaceOpenXR.cpp
+++ b/src/gdclasses/XRInterfaceOpenXR.cpp
@@ -1,0 +1,5 @@
+/////////////////////////////////////////////////////////////////////////////////////
+// This is a placeholder for our XRInterfaceOpenXR GD extension class
+// ARVRInterface will be rewritten into this.
+
+#include "gdclasses/XRInterfaceOpenXR.h"

--- a/src/gdclasses/XRInterfaceOpenXR.h
+++ b/src/gdclasses/XRInterfaceOpenXR.h
@@ -1,0 +1,10 @@
+/////////////////////////////////////////////////////////////////////////////////////
+// This is a placeholder for our XRInterfaceOpenXR GD extension class
+// ARVRInterface will be rewritten into this.
+
+#ifndef XR_INTERFACE_OPENXR_H
+#define XR_INTERFACE_OPENXR_H
+
+#include "openxr/OpenXRApi.h"
+
+#endif // !XR_INTERFACE_OPENXR_H

--- a/src/godot_openxr.cpp
+++ b/src/godot_openxr.cpp
@@ -5,10 +5,10 @@
 // with loads of help from Thomas "Karroffel" Herzog
 
 #include "godot_openxr.h"
-#include "openxr/OpenXRConfig.h"
-#include "openxr/OpenXRHand.h"
-#include "openxr/OpenXRPose.h"
-#include "openxr/OpenXRSkeleton.h"
+#include "gdclasses/OpenXRConfig.h"
+#include "gdclasses/OpenXRHand.h"
+#include "gdclasses/OpenXRPose.h"
+#include "gdclasses/OpenXRSkeleton.h"
 
 void GDN_EXPORT godot_openxr_gdnative_init(godot_gdnative_init_options *o) {
 	godot::Godot::gdnative_init(o);


### PR DESCRIPTION
This is just some cleanup, I've moved the classes that are exposed to Godot into their own subfolder. 
The source code that remains in the `openxr` folder is now purely our implementation of the OpenXR system.

I think there is an argument to be made to rename the `OpenXRAPI` class to something else because it looks too similar to the naming we've applied to the exposed classes.

Finally I've added a placeholder set of files for `XRInterfaceOpenXR` which will replace `ARVRInterface` in Godot 4. I've left the `ARVRInterface` implementation in the root of the source folder because at this time this is not strictly speaking a class and it will be completely rewritten for Godot 4 anyway. 