### PR TITLE
Improved extension checking logic

### DIFF
--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -4,6 +4,9 @@ func _ready():
 	# Start our OpenXR session
 	$FPSController.initialise()
 
+	# Just for testing, output the enabled extensions
+	print("Enabled extensions: " + str($FPSController/Configuration.get_enabled_extensions()))
+
 func _process(delta):
 	# Test for escape to close application, space to reset our reference frame
 	if (Input.is_key_pressed(KEY_ESCAPE)):

--- a/src/gdclasses/OpenXRConfig.cpp
+++ b/src/gdclasses/OpenXRConfig.cpp
@@ -10,9 +10,15 @@ using namespace godot;
 void OpenXRConfig::_register_methods() {
 	register_method("keep_3d_linear", &OpenXRConfig::keep_3d_linear);
 
+	register_method("get_view_config_type", &OpenXRConfig::get_view_config_type);
+	register_method("set_view_config_type", &OpenXRConfig::set_view_config_type);
+	register_property<OpenXRConfig, int>("view_configuration", &OpenXRConfig::set_view_config_type, &OpenXRConfig::get_view_config_type, 1, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, "Mono,Stereo");
+
 	register_method("get_form_factor", &OpenXRConfig::get_form_factor);
 	register_method("set_form_factor", &OpenXRConfig::set_form_factor);
 	register_property<OpenXRConfig, int>("form_factor", &OpenXRConfig::set_form_factor, &OpenXRConfig::get_form_factor, 1, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, "Not set,HMD,Hand Held");
+
+	register_method("get_enabled_extensions", &OpenXRConfig::get_enabled_extensions);
 
 	register_method("get_action_sets", &OpenXRConfig::get_action_sets);
 	register_method("set_action_sets", &OpenXRConfig::set_action_sets);
@@ -45,6 +51,55 @@ bool OpenXRConfig::keep_3d_linear() const {
 	}
 }
 
+int OpenXRConfig::get_view_config_type() const {
+	if (openxr_api == NULL) {
+		return 1;
+	} else {
+		XrViewConfigurationType config_type = openxr_api->get_view_configuration_type();
+		switch (config_type) {
+			case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO: {
+				return 0;
+			}; break;
+			case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO: {
+				return 1;
+			}; break;
+			/* These are not (yet) supported, adding them in here for future reference
+			case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO: {
+				return 2;
+			}; break;
+			case XR_VIEW_CONFIGURATION_TYPE_SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT: {
+				return 3;
+			}; break;
+			*/
+			default: {
+				// we don't support the others
+				Godot::print_error(String("Unsupported configuration type set: ") + String::num_int64(config_type), __FUNCTION__, __FILE__, __LINE__);
+				return 1;
+			}; break;
+		}
+	}
+}
+
+void OpenXRConfig::set_view_config_type(const int p_config_type) {
+	// TODO may need to add something here that this is read only after initialisation
+	if (openxr_api == NULL) {
+		Godot::print("OpenXR object wasn't constructed.");
+	} else {
+		switch (p_config_type) {
+			case 0: {
+				openxr_api->set_view_configuration_type(XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO);
+			}; break;
+			case 1: {
+				openxr_api->set_view_configuration_type(XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO);
+			}; break;
+			default: {
+				// Shouldn't be set, just give error.
+				Godot::print_error(String("Unsupported configuration type set: ") + String::num_int64(p_config_type), __FUNCTION__, __FILE__, __LINE__);
+			}; break;
+		}
+	}
+}
+
 int OpenXRConfig::get_form_factor() const {
 	if (openxr_api == NULL) {
 		return 0;
@@ -53,11 +108,20 @@ int OpenXRConfig::get_form_factor() const {
 	}
 }
 
-void OpenXRConfig::set_form_factor(int p_form_factor) {
+void OpenXRConfig::set_form_factor(const int p_form_factor) {
 	if (openxr_api == NULL) {
 		Godot::print("OpenXR object wasn't constructed.");
 	} else {
 		openxr_api->set_form_factor((XrFormFactor)p_form_factor);
+	}
+}
+
+godot::Array OpenXRConfig::get_enabled_extensions() const {
+	if (openxr_api == NULL) {
+		godot::Array arr;
+		return arr;
+	} else {
+		return openxr_api->get_enabled_extensions();
 	}
 }
 

--- a/src/gdclasses/OpenXRConfig.h
+++ b/src/gdclasses/OpenXRConfig.h
@@ -24,8 +24,13 @@ public:
 
 	bool keep_3d_linear() const;
 
+	int get_view_config_type() const;
+	void set_view_config_type(const int p_config_type);
+
 	int get_form_factor() const;
-	void set_form_factor(int p_form_factor);
+	void set_form_factor(const int p_form_factor);
+
+	godot::Array get_enabled_extensions() const;
 
 	String get_action_sets() const;
 	void set_action_sets(const String p_action_sets);

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -167,9 +167,22 @@ private:
 	godot::OS::VideoDriver video_driver = godot::OS::VIDEO_DRIVER_GLES3;
 
 	// extensions
+	// TODO consider basing this on an enumeration.
+	bool performance_settings_ext = false;
 	bool hand_tracking_ext = false;
 	bool hand_motion_range_ext = false;
 	bool monado_stick_on_ball_ext = false;
+
+	bool fb_display_refresh_rate_ext = false;
+	bool fb_color_space_ext = false;
+	bool fb_swapchain_update_state_ext = false;
+	bool fb_swapchain_update_state_opengles_ext = false;
+	bool fb_foveation_ext = false;
+	bool fb_foveation_configuration_ext = false;
+
+	std::vector<const char *> enabled_extensions;
+
+	// feature flags
 	bool hand_tracking_supported = false;
 
 	XrViewConfigurationType view_config_type = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
@@ -310,8 +323,13 @@ public:
 	void set_motion_range(uint32_t p_hand, XrHandJointsMotionRangeEXT p_motion_range);
 
 	// config
+	XrViewConfigurationType get_view_configuration_type() const;
+	void set_view_configuration_type(const XrViewConfigurationType p_view_configuration_type);
+
 	XrFormFactor get_form_factor() const;
-	void set_form_factor(XrFormFactor p_form_factor);
+	void set_form_factor(const XrFormFactor p_form_factor);
+
+	godot::Array get_enabled_extensions() const;
 
 	static const char *default_action_sets_json;
 	godot::String get_action_sets_json() const;


### PR DESCRIPTION
This changes the logic that checks and enabled extensions in our plugin.
It works with a `map` to which we add the extensions we want.
The entry then points to a boolean that the logic either sets or clears depending on whether the extension is available.
If this pointer is a `nullptr` we deem the extension as a requirement and it not being available will fail initialization of the plugin.
Finally we enabled all extensions that were requested and found.

The boolean flags allow further logic to actually implement the usage of the extension.

I've also moved most of the FB extensions out of the Android only sphere, I suspect a number of these will become extensions also implemented by other vendors as has happened with a number of Microsoft and Valve extensions that still bear their names (especially around refresh rates and such, really weird those aren't part of the core spec already). 