### PR TITLE
Implement refresh rate API

### DIFF
--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -6,6 +6,7 @@ func _ready():
 
 	# Just for testing, output the enabled extensions
 	print("Enabled extensions: " + str($FPSController/Configuration.get_enabled_extensions()))
+	print("Supported refresh rates: " + str($FPSController/Configuration.get_available_refresh_rates()))
 
 func _process(delta):
 	# Test for escape to close application, space to reset our reference frame

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -43,6 +43,9 @@ directional_shadow_max_distance = 20.0
 
 [node name="FPSController" parent="." instance=ExtResource( 4 )]
 
+[node name="Configuration" parent="FPSController" index="0"]
+refresh_rate = 0.0
+
 [node name="ShadowHead" type="MeshInstance" parent="FPSController/ARVRCamera" index="0"]
 transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, -0.0187781, 0.103895 )
 layers = 524288

--- a/demo/addons/godot-openxr/scenes/first_person_controller_vr.gd
+++ b/demo/addons/godot-openxr/scenes/first_person_controller_vr.gd
@@ -24,7 +24,18 @@ func initialise() -> bool:
 		vp.keep_3d_linear = $Configuration.keep_3d_linear()
 
 		# increase our physics engine update speed
-		Engine.iterations_per_second = 144
+		var refresh_rate = $Configuration.get_refresh_rate()
+		if refresh_rate == 0:
+			# Only Facebook Reality Labs supports this at this time
+			print("No refresh rate given by XR runtime")
+
+			# Use something sufficiently high
+			Engine.iterations_per_second = 144
+		else:
+			print("HMD refresh rate is set to " + str(refresh_rate))
+
+			# Match our physics to our HMD
+			Engine.iterations_per_second = refresh_rate
 
 		# $Left_hand.set_physics_process(true)
 		return true

--- a/src/gdclasses/OpenXRConfig.cpp
+++ b/src/gdclasses/OpenXRConfig.cpp
@@ -8,6 +8,8 @@
 using namespace godot;
 
 void OpenXRConfig::_register_methods() {
+	// In Godot 4 we'll move these into XRInterfaceOpenXR and add groups to our properties
+
 	register_method("keep_3d_linear", &OpenXRConfig::keep_3d_linear);
 
 	register_method("get_view_config_type", &OpenXRConfig::get_view_config_type);
@@ -17,6 +19,11 @@ void OpenXRConfig::_register_methods() {
 	register_method("get_form_factor", &OpenXRConfig::get_form_factor);
 	register_method("set_form_factor", &OpenXRConfig::set_form_factor);
 	register_property<OpenXRConfig, int>("form_factor", &OpenXRConfig::set_form_factor, &OpenXRConfig::get_form_factor, 1, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, "Not set,HMD,Hand Held");
+
+	register_method("get_refresh_rate", &OpenXRConfig::get_refresh_rate);
+	register_method("set_refresh_rate", &OpenXRConfig::set_refresh_rate);
+	register_property<OpenXRConfig, double>("refresh_rate", &OpenXRConfig::set_refresh_rate, &OpenXRConfig::get_refresh_rate, 1, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_NOEDITOR);
+	register_method("get_available_refresh_rates", &OpenXRConfig::get_available_refresh_rates);
 
 	register_method("get_enabled_extensions", &OpenXRConfig::get_enabled_extensions);
 
@@ -113,6 +120,29 @@ void OpenXRConfig::set_form_factor(const int p_form_factor) {
 		Godot::print("OpenXR object wasn't constructed.");
 	} else {
 		openxr_api->set_form_factor((XrFormFactor)p_form_factor);
+	}
+}
+
+double OpenXRConfig::get_refresh_rate() const {
+	if (openxr_api == NULL) {
+		return 0;
+	} else {
+		return (int)openxr_api->get_refresh_rate();
+	}
+}
+
+void OpenXRConfig::set_refresh_rate(const double p_refresh_rate) {
+	if (openxr_api != NULL) {
+		openxr_api->set_refresh_rate(p_refresh_rate);
+	}
+}
+
+godot::Array OpenXRConfig::get_available_refresh_rates() const {
+	if (openxr_api == NULL) {
+		godot::Array arr;
+		return arr;
+	} else {
+		return openxr_api->get_available_refresh_rates();
 	}
 }
 

--- a/src/gdclasses/OpenXRConfig.h
+++ b/src/gdclasses/OpenXRConfig.h
@@ -30,6 +30,10 @@ public:
 	int get_form_factor() const;
 	void set_form_factor(const int p_form_factor);
 
+	double get_refresh_rate() const;
+	void set_refresh_rate(const double p_refresh_rate);
+	godot::Array get_available_refresh_rates() const;
+
 	godot::Array get_enabled_extensions() const;
 
 	String get_action_sets() const;

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -24,20 +24,6 @@
 #include <vector>
 
 #include "xrmath.h"
-#include <openxr/openxr.h>
-
-#define XR_MND_BALL_ON_STICK_EXTENSION_NAME "XR_MNDX_ball_on_a_stick_controller"
-
-#ifdef WIN32
-#define XR_USE_PLATFORM_WIN32
-#define XR_USE_GRAPHICS_API_OPENGL
-#elif ANDROID
-#define XR_USE_PLATFORM_ANDROID
-#define XR_USE_GRAPHICS_API_OPENGL_ES
-#else
-#define XR_USE_PLATFORM_XLIB
-#define XR_USE_GRAPHICS_API_OPENGL
-#endif
 
 #ifdef WIN32
 #include <glad/glad.h>
@@ -57,8 +43,9 @@
 #include <X11/Xlib.h>
 #endif
 
-// #include <gdnative/gdnative.h>
-#include <openxr/openxr.h>
+#include "openxr/extensions/xr_ext_hand_tracking_extension.h"
+#include "openxr/extensions/xr_fb_display_refresh_rate_extension.h"
+#include "openxr/openxr_inc.h"
 #include <openxr/openxr_platform.h>
 
 // forward declare this
@@ -247,15 +234,15 @@ private:
 	bool isReferenceSpaceSupported(XrReferenceSpaceType type);
 
 	bool initialiseInstance();
-	bool initialiseExtensions();
+	bool initialise_extensions();
 	bool initialiseSession();
 	bool initialiseSpaces();
 	void cleanupSpaces();
 	bool initialiseSwapChains();
 	void cleanupSwapChains();
 
-	bool initialiseHandTracking();
-	void cleanupHandTracking();
+	bool initialise_hand_tracking();
+	void cleanup_hand_tracking();
 
 	bool loadActionSets();
 	bool bindActionSets();
@@ -301,7 +288,7 @@ public:
 	bool get_keep_3d_linear() { return keep_3d_linear; };
 
 	template <class... Args>
-	bool xr_result(XrResult result, const char *format, Args... values) {
+	bool xr_result(XrResult result, const char *format, Args... values) const {
 		if (XR_SUCCEEDED(result))
 			return true;
 
@@ -328,6 +315,10 @@ public:
 
 	XrFormFactor get_form_factor() const;
 	void set_form_factor(const XrFormFactor p_form_factor);
+
+	double get_refresh_rate() const;
+	void set_refresh_rate(const double p_refresh_rate);
+	godot::Array get_available_refresh_rates() const;
 
 	godot::Array get_enabled_extensions() const;
 

--- a/src/openxr/extensions/xr_ext_hand_tracking_extension.cpp
+++ b/src/openxr/extensions/xr_ext_hand_tracking_extension.cpp
@@ -1,0 +1,59 @@
+#include "xr_ext_hand_tracking_extension.h"
+
+PFN_xrCreateHandTrackerEXT xrCreateHandTrackerEXT_ptr = nullptr;
+
+XRAPI_ATTR XrResult XRAPI_CALL xrCreateHandTrackerEXT(
+		XrSession session,
+		const XrHandTrackerCreateInfoEXT *createInfo,
+		XrHandTrackerEXT *handTracker) {
+	if (xrCreateHandTrackerEXT_ptr == nullptr) {
+		return XR_ERROR_HANDLE_INVALID;
+	}
+
+	return (*xrCreateHandTrackerEXT_ptr)(session, createInfo, handTracker);
+}
+
+PFN_xrDestroyHandTrackerEXT xrDestroyHandTrackerEXT_ptr = nullptr;
+
+XRAPI_ATTR XrResult XRAPI_CALL xrDestroyHandTrackerEXT(
+		XrHandTrackerEXT handTracker) {
+	if (xrDestroyHandTrackerEXT_ptr == nullptr) {
+		return XR_ERROR_HANDLE_INVALID;
+	}
+
+	return (*xrDestroyHandTrackerEXT_ptr)(handTracker);
+}
+
+PFN_xrLocateHandJointsEXT xrLocateHandJointsEXT_ptr = nullptr;
+
+XRAPI_ATTR XrResult XRAPI_CALL xrLocateHandJointsEXT(
+		XrHandTrackerEXT handTracker,
+		const XrHandJointsLocateInfoEXT *locateInfo,
+		XrHandJointLocationsEXT *locations) {
+	if (xrLocateHandJointsEXT_ptr == nullptr) {
+		return XR_ERROR_HANDLE_INVALID;
+	}
+
+	return (*xrLocateHandJointsEXT_ptr)(handTracker, locateInfo, locations);
+}
+
+XrResult initialise_ext_hand_tracking_extension(XrInstance instance) {
+	XrResult result;
+
+	result = xrGetInstanceProcAddr(instance, "xrCreateHandTrackerEXT", (PFN_xrVoidFunction *)&xrCreateHandTrackerEXT_ptr);
+	if (result != XR_SUCCESS) {
+		return result;
+	}
+
+	result = xrGetInstanceProcAddr(instance, "xrDestroyHandTrackerEXT", (PFN_xrVoidFunction *)&xrDestroyHandTrackerEXT_ptr);
+	if (result != XR_SUCCESS) {
+		return result;
+	}
+
+	result = xrGetInstanceProcAddr(instance, "xrLocateHandJointsEXT", (PFN_xrVoidFunction *)&xrLocateHandJointsEXT_ptr);
+	if (result != XR_SUCCESS) {
+		return result;
+	}
+
+	return XR_SUCCESS;
+}

--- a/src/openxr/extensions/xr_ext_hand_tracking_extension.h
+++ b/src/openxr/extensions/xr_ext_hand_tracking_extension.h
@@ -1,0 +1,29 @@
+#ifndef EXT_HAND_TRACKING_EXT
+#define EXT_HAND_TRACKING_EXT
+
+#include "openxr/openxr_inc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+XRAPI_ATTR XrResult XRAPI_CALL xrCreateHandTrackerEXT(
+		XrSession session,
+		const XrHandTrackerCreateInfoEXT *createInfo,
+		XrHandTrackerEXT *handTracker);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrDestroyHandTrackerEXT(
+		XrHandTrackerEXT handTracker);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrLocateHandJointsEXT(
+		XrHandTrackerEXT handTracker,
+		const XrHandJointsLocateInfoEXT *locateInfo,
+		XrHandJointLocationsEXT *locations);
+
+XrResult initialise_ext_hand_tracking_extension(XrInstance instance);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !EXT_HAND_TRACKING_EXT

--- a/src/openxr/extensions/xr_fb_display_refresh_rate_extension.cpp
+++ b/src/openxr/extensions/xr_fb_display_refresh_rate_extension.cpp
@@ -1,0 +1,58 @@
+#include "xr_fb_display_refresh_rate_extension.h"
+
+PFN_xrEnumerateDisplayRefreshRatesFB xrEnumerateDisplayRefreshRatesFB_ptr = nullptr;
+
+XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateDisplayRefreshRatesFB(
+		XrSession session,
+		uint32_t displayRefreshRateCapacityInput,
+		uint32_t *displayRefreshRateCountOutput,
+		float *displayRefreshRates) {
+	if (xrEnumerateDisplayRefreshRatesFB_ptr == nullptr) {
+		return XR_ERROR_HANDLE_INVALID;
+	}
+
+	return (*xrEnumerateDisplayRefreshRatesFB_ptr)(session, displayRefreshRateCapacityInput, displayRefreshRateCountOutput, displayRefreshRates);
+}
+
+PFN_xrGetDisplayRefreshRateFB xrGetDisplayRefreshRateFB_ptr = nullptr;
+
+XRAPI_ATTR XrResult XRAPI_CALL xrGetDisplayRefreshRateFB(
+		XrSession session,
+		float *displayRefreshRate) {
+	if (xrGetDisplayRefreshRateFB_ptr == nullptr) {
+		return XR_ERROR_HANDLE_INVALID;
+	}
+
+	return (*xrGetDisplayRefreshRateFB_ptr)(session, displayRefreshRate);
+}
+
+PFN_xrRequestDisplayRefreshRateFB xrRequestDisplayRefreshRateFB_ptr = nullptr;
+
+XRAPI_ATTR XrResult XRAPI_CALL xrRequestDisplayRefreshRateFB(
+		XrSession session,
+		float displayRefreshRate) {
+	if (xrRequestDisplayRefreshRateFB_ptr == nullptr) {
+		return XR_ERROR_HANDLE_INVALID;
+	}
+
+	return (*xrRequestDisplayRefreshRateFB_ptr)(session, displayRefreshRate);
+}
+
+XrResult initialise_fb_display_refresh_rate_extension(XrInstance instance) {
+	XrResult result;
+
+	result = xrGetInstanceProcAddr(instance, "xrEnumerateDisplayRefreshRatesFB", (PFN_xrVoidFunction *)&xrEnumerateDisplayRefreshRatesFB_ptr);
+	if (result != XR_SUCCESS) {
+		return result;
+	}
+	result = xrGetInstanceProcAddr(instance, "xrGetDisplayRefreshRateFB", (PFN_xrVoidFunction *)&xrGetDisplayRefreshRateFB_ptr);
+	if (result != XR_SUCCESS) {
+		return result;
+	}
+	result = xrGetInstanceProcAddr(instance, "xrRequestDisplayRefreshRateFB", (PFN_xrVoidFunction *)&xrRequestDisplayRefreshRateFB_ptr);
+	if (result != XR_SUCCESS) {
+		return result;
+	}
+
+	return XR_SUCCESS;
+}

--- a/src/openxr/extensions/xr_fb_display_refresh_rate_extension.h
+++ b/src/openxr/extensions/xr_fb_display_refresh_rate_extension.h
@@ -1,0 +1,30 @@
+#ifndef FB_DRR_EXT
+#define FB_DRR_EXT
+
+#include "openxr/openxr_inc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateDisplayRefreshRatesFB(
+		XrSession session,
+		uint32_t displayRefreshRateCapacityInput,
+		uint32_t *displayRefreshRateCountOutput,
+		float *displayRefreshRates);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrGetDisplayRefreshRateFB(
+		XrSession session,
+		float *displayRefreshRate);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrRequestDisplayRefreshRateFB(
+		XrSession session,
+		float displayRefreshRate);
+
+XrResult initialise_fb_display_refresh_rate_extension(XrInstance instance);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/openxr/openxr_inc.h
+++ b/src/openxr/openxr_inc.h
@@ -1,0 +1,14 @@
+#define XR_MND_BALL_ON_STICK_EXTENSION_NAME "XR_MNDX_ball_on_a_stick_controller"
+
+#ifdef WIN32
+#define XR_USE_PLATFORM_WIN32
+#define XR_USE_GRAPHICS_API_OPENGL
+#elif ANDROID
+#define XR_USE_PLATFORM_ANDROID
+#define XR_USE_GRAPHICS_API_OPENGL_ES
+#else
+#define XR_USE_PLATFORM_XLIB
+#define XR_USE_GRAPHICS_API_OPENGL
+#endif
+
+#include <openxr/openxr.h>


### PR DESCRIPTION
This PR implements an API to getting/setting refresh rates on the HMD.

These functions currently only work on the Oculus runtime, only FB has implemented an extension for this, hopefully other vendors will follow suit and add this to their OpenXR implementation as well either through the same extension or a core extension. It's important that we assume this will happen some day and expose an API to the end user that is vendor agnostic.

The new feature exposes a number of functions and properties through OpenXRConfig (note that in Godot 4 I intend to move them into the XRInterfaceOpenXR class and use proper groups).
The functions added are:
`get_refresh_rate` : Returns the current refresh rate for the HMD (return 0 if none provided or not supported)
`set_refresh_rate` : Will attempt to change the refresh rate on the HMD (will be ignore if not supported or if an invalid value is provided)
`get_available_refresh_rates` : Returns an array of refresh rates supported by the HMD (empty if not supported)

The following property has been added:
`refresh_rate` : The refresh rate for the HMD, this is a runtime only property.

As part of this PR I've also moved some of the hand tracking code into separate files in the same way as I've done this for the refresh rate. Currently this is only the code for obtaining function pointers and implementing access to these functions. Turns out the OpenXR loader does not provide this functionality for extensions. 

I think more of the hand tracking and refresh rate logic can eventually be moved into these files to better segregate the logic instead of `OpenXRApi` just growing and growing but that is something for another day.