### PR TITLE
Improvements to input map

### DIFF
--- a/demo/ControllerInfo.gd
+++ b/demo/ControllerInfo.gd
@@ -17,9 +17,19 @@ func _process(_delta : float):
 
 		var joy_x = controller.get_joystick_axis(JOY_AXIS_0)
 		var joy_y = controller.get_joystick_axis(JOY_AXIS_1)
-		$Container/Control/Joystick/Puck.rect_position = Vector2(23 + joy_x * 23, 23 - joy_y * 23)
+		$Container/Joysticks/Primary/Background.color = Color(1.0, 1.0, 1.0, 1.0) if controller.is_button_pressed(JOY_BUTTON_12) else Color(0.7, 0.7, 0.7, 1.0)
+		$Container/Joysticks/Primary/Background/Puck.rect_position = Vector2(23 + joy_x * 23, 23 - joy_y * 23)
+		$Container/Joysticks/Primary/Background/Puck.color = Color(0.0, 0.0, 1.0, 1.0) if controller.is_button_pressed(JOY_BUTTON_14) else Color(0.0, 0.0, 0.0, 1.0)
+
+		joy_x = controller.get_joystick_axis(JOY_AXIS_6)
+		joy_y = controller.get_joystick_axis(JOY_AXIS_7)
+		$Container/Joysticks/Secondary/Background.color = Color(1.0, 1.0, 1.0, 1.0) if controller.is_button_pressed(JOY_BUTTON_11) else Color(0.7, 0.7, 0.7, 1.0)
+		$Container/Joysticks/Secondary/Background/Puck.rect_position = Vector2(23 + joy_x * 23, 23 - joy_y * 23)
+		$Container/Joysticks/Secondary/Background/Puck.color = Color(0.0, 0.0, 1.0, 1.0) if controller.is_button_pressed(JOY_BUTTON_13) else Color(0.0, 0.0, 0.0, 1.0)
 
 		$Container/AXButton/Value.pressed = controller.is_button_pressed(JOY_BUTTON_7)
-		$Container/BYMButton/Value.pressed = controller.is_button_pressed(JOY_BUTTON_1)
+		$Container/BYButton/Value.pressed = controller.is_button_pressed(JOY_BUTTON_1)
+		$Container/MenuButton/Value.pressed = controller.is_button_pressed(JOY_BUTTON_3)
+		$Container/SelectButton/Value.pressed = controller.is_button_pressed(JOY_BUTTON_4)
 		$Container/TriggerButton/Value.pressed = controller.is_button_pressed(JOY_VR_TRIGGER)
 		$Container/SideButton/Value.pressed = controller.is_button_pressed(JOY_VR_GRIP)

--- a/demo/ControllerInfo.tscn
+++ b/demo/ControllerInfo.tscn
@@ -34,20 +34,47 @@ margin_right = 500.0
 margin_bottom = 36.0
 rect_min_size = Vector2( 500, 0 )
 
-[node name="Control" type="Control" parent="Container"]
+[node name="Joysticks" type="HBoxContainer" parent="Container"]
 margin_top = 40.0
 margin_right = 500.0
 margin_bottom = 90.0
-rect_min_size = Vector2( 0, 50 )
 
-[node name="Joystick" type="ColorRect" parent="Container/Control"]
+[node name="Primary" type="Control" parent="Container/Joysticks"]
+margin_right = 50.0
+margin_bottom = 50.0
+rect_min_size = Vector2( 50, 50 )
+
+[node name="Background" type="ColorRect" parent="Container/Joysticks/Primary"]
 margin_right = 50.0
 margin_bottom = 50.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Puck" type="ColorRect" parent="Container/Control/Joystick"]
+[node name="Puck" type="ColorRect" parent="Container/Joysticks/Primary/Background"]
+margin_left = 23.0
+margin_top = 23.0
+margin_right = 27.0
+margin_bottom = 27.0
+color = Color( 0, 0, 0, 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Secondary" type="Control" parent="Container/Joysticks"]
+margin_left = 54.0
+margin_right = 104.0
+margin_bottom = 50.0
+rect_min_size = Vector2( 50, 50 )
+
+[node name="Background" type="ColorRect" parent="Container/Joysticks/Secondary"]
+margin_right = 50.0
+margin_bottom = 50.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Puck" type="ColorRect" parent="Container/Joysticks/Secondary/Background"]
 margin_left = 23.0
 margin_top = 23.0
 margin_right = 27.0
@@ -65,31 +92,63 @@ margin_bottom = 32.0
 
 [node name="Label" type="Label" parent="Container/AXButton"]
 margin_left = 28.0
-margin_right = 142.0
+margin_right = 141.0
 margin_bottom = 32.0
 custom_fonts/font = ExtResource( 2 )
 text = "A/X button"
 
-[node name="BYMButton" type="HBoxContainer" parent="Container"]
+[node name="BYButton" type="HBoxContainer" parent="Container"]
 margin_top = 130.0
 margin_right = 500.0
 margin_bottom = 162.0
 
-[node name="Value" type="CheckBox" parent="Container/BYMButton"]
+[node name="Value" type="CheckBox" parent="Container/BYButton"]
 margin_right = 24.0
 margin_bottom = 32.0
 
-[node name="Label" type="Label" parent="Container/BYMButton"]
+[node name="Label" type="Label" parent="Container/BYButton"]
 margin_left = 28.0
-margin_right = 207.0
+margin_right = 139.0
 margin_bottom = 32.0
 custom_fonts/font = ExtResource( 2 )
-text = "B/Y/Menu button"
+text = "B/Y button"
 
-[node name="TriggerButton" type="HBoxContainer" parent="Container"]
+[node name="MenuButton" type="HBoxContainer" parent="Container"]
 margin_top = 166.0
 margin_right = 500.0
 margin_bottom = 198.0
+
+[node name="Value" type="CheckBox" parent="Container/MenuButton"]
+margin_right = 24.0
+margin_bottom = 32.0
+
+[node name="Label" type="Label" parent="Container/MenuButton"]
+margin_left = 28.0
+margin_right = 159.0
+margin_bottom = 32.0
+custom_fonts/font = ExtResource( 2 )
+text = "Menu button"
+
+[node name="SelectButton" type="HBoxContainer" parent="Container"]
+margin_top = 202.0
+margin_right = 500.0
+margin_bottom = 234.0
+
+[node name="Value" type="CheckBox" parent="Container/SelectButton"]
+margin_right = 24.0
+margin_bottom = 32.0
+
+[node name="Label" type="Label" parent="Container/SelectButton"]
+margin_left = 28.0
+margin_right = 164.0
+margin_bottom = 32.0
+custom_fonts/font = ExtResource( 2 )
+text = "Select button"
+
+[node name="TriggerButton" type="HBoxContainer" parent="Container"]
+margin_top = 238.0
+margin_right = 500.0
+margin_bottom = 270.0
 
 [node name="Value" type="CheckBox" parent="Container/TriggerButton"]
 margin_right = 24.0
@@ -97,15 +156,15 @@ margin_bottom = 32.0
 
 [node name="Label" type="Label" parent="Container/TriggerButton"]
 margin_left = 28.0
-margin_right = 102.0
+margin_right = 100.0
 margin_bottom = 32.0
 custom_fonts/font = ExtResource( 2 )
 text = "Trigger"
 
 [node name="SideButton" type="HBoxContainer" parent="Container"]
-margin_top = 202.0
+margin_top = 274.0
 margin_right = 500.0
-margin_bottom = 234.0
+margin_bottom = 306.0
 
 [node name="Value" type="CheckBox" parent="Container/SideButton"]
 margin_right = 24.0

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -119,6 +119,7 @@ material/0 = null
 motion_range = 1
 
 [node name="Skeleton" parent="FPSController/LeftHand/HandModel/Armature001" index="0"]
+bones/9/bound_children = [  ]
 motion_range = 1
 
 [node name="IndexTip" parent="FPSController/LeftHand/HandModel/Armature001/Skeleton" index="1"]
@@ -134,6 +135,7 @@ motion_range = 1
 albedo_texture = ExtResource( 5 )
 
 [node name="Skeleton" parent="FPSController/RightHand/HandModel/Armature" index="0"]
+bones/9/bound_children = [  ]
 motion_range = 1
 
 [node name="IndexTip" parent="FPSController/RightHand/HandModel/Armature/Skeleton" index="1"]

--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -5,6 +5,7 @@ Changes to the Godot OpenXR asset
 -------------------
 - Implemented Android build (currently using Oculus loader, Quest support only)
 - Fix invalid transforms generated from invalid space locations when using OpenXRSkeleton or OpenXRPose.
+- Improved action map supporting secondary thumbstick/trackpad, menu and select buttons.
 
 1.0.3
 -------------------

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -19,410 +19,672 @@
 // TODO: it makes sense to include this in source because we'll store any user defined version in Godot scenes
 // but there has to be a nicer way to embed it :)
 
-const char *OpenXRApi::default_action_sets_json = "[\n"
-												  "	{\n"
-												  "		\"name\": \"godot\",\n"
-												  "		\"localised_name\": \"Action Set Used by Godot\",\n"
-												  "		\"priority\": 0,\n"
-												  "		\"actions\": [\n"
-												  "			{\n"
-												  "				\"type\": \"pose\",\n"
-												  "				\"name\": \"aim_pose\",\n"
-												  "				\"localised_name\": \"Aim Pose\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"pose\",\n"
-												  "				\"name\": \"grip_pose\",\n"
-												  "				\"localised_name\": \"Grip Pose\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"float\",\n"
-												  "				\"name\": \"front_trigger\",\n"
-												  "				\"localised_name\": \"Front trigger\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"float\",\n"
-												  "				\"name\": \"side_trigger\",\n"
-												  "				\"localised_name\": \"Side trigger\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"vector2\",\n"
-												  "				\"name\": \"joystick\",\n"
-												  "				\"localised_name\": \"Joystick\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"bool\",\n"
-												  "				\"name\": \"ax_buttons\",\n"
-												  "				\"localised_name\": \"A and X buttons\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"bool\",\n"
-												  "				\"name\": \"bym_button\",\n"
-												  "				\"localised_name\": \"B, Y and menu buttons\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"bool\",\n"
-												  "				\"name\": \"front_button\",\n"
-												  "				\"localised_name\": \"Front trigger as a button\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"bool\",\n"
-												  "				\"name\": \"side_button\",\n"
-												  "				\"localised_name\": \"Side trigger as a button\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"bool\",\n"
-												  "				\"name\": \"joystick_button\",\n"
-												  "				\"localised_name\": \"Thumbstick click\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "			{\n"
-												  "				\"type\": \"vibration\",\n"
-												  "				\"name\": \"haptic\",\n"
-												  "				\"localised_name\": \"Controller haptic vibration\",\n"
-												  "				\"paths\": [\n"
-												  "					\"/user/hand/left\",\n"
-												  "					\"/user/hand/right\",\n"
-												  "				],\n"
-												  "			},\n"
-												  "		],\n"
-												  "	}\n"
-												  "]\n";
+const char *OpenXRApi::default_action_sets_json = R"===(
+[
+	{
+		"name": "godot",
+		"localised_name": "Action Set Used by Godot",
+		"priority": 0,
+		"actions": [
+			{
+				"type": "pose",
+				"name": "aim_pose",
+				"localised_name": "Aim Pose",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "pose",
+				"name": "grip_pose",
+				"localised_name": "Grip Pose",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "float",
+				"name": "front_trigger",
+				"localised_name": "Front trigger",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "float",
+				"name": "side_trigger",
+				"localised_name": "Side trigger",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "vector2",
+				"name": "primary",
+				"localised_name": "Primary joystick/thumbstick/trackpad",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "vector2",
+				"name": "secondary",
+				"localised_name": "Secondary joystick/thumbstick/trackpad",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "ax_buttons",
+				"localised_name": "A and X buttons",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "by_button",
+				"localised_name": "B, Y buttons",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "menu_button",
+				"localised_name": "Menu button",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "select_button",
+				"localised_name": "Select button",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "front_button",
+				"localised_name": "Front trigger as a button",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "side_button",
+				"localised_name": "Side trigger as a button",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "primary_button",
+				"localised_name": "Primary joystick/thumbstick/trackpad click",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "secondary_button",
+				"localised_name": "Secondary joystick/thumbstick/trackpad click",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "primary_touch",
+				"localised_name": "Primary joystick/thumbstick/trackpad touch",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "bool",
+				"name": "secondary_touch",
+				"localised_name": "Secondary joystick/thumbstick/trackpad touch",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			},
+			{
+				"type": "vibration",
+				"name": "haptic",
+				"localised_name": "Controller haptic vibration",
+				"paths": [
+					"/user/hand/left",
+					"/user/hand/right"
+				]
+			}
+		]
+	}
+]
+)===";
 
 // documentated interaction profiles can be found here: https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#semantic-path-interaction-profiles
-const char *OpenXRApi::default_interaction_profiles_json = "[\n"
-														   "	{\n"
-														   "		\"path\": \"/interaction_profiles/khr/simple_controller\",\n"
-														   "		\"bindings\": [\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"aim_pose\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/aim/pose\",\n"
-														   "					\"/user/hand/right/input/aim/pose\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"grip_pose\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/grip/pose\",\n"
-														   "					\"/user/hand/right/input/grip/pose\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"haptic\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/output/haptic\",\n"
-														   "					\"/user/hand/right/output/haptic\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "		],\n"
-														   "	},\n"
-														   "	{\n"
-														   "		\"path\": \"/interaction_profiles/microsoft/motion_controller\",\n"
-														   "		\"bindings\": [\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"aim_pose\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/aim/pose\",\n"
-														   "					\"/user/hand/right/input/aim/pose\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"grip_pose\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/grip/pose\",\n"
-														   "					\"/user/hand/right/input/grip/pose\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"front_trigger\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/trigger/value\",\n"
-														   "					\"/user/hand/right/input/trigger/value\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"side_trigger\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/squeeze/click\",\n"
-														   "					\"/user/hand/right/input/squeeze/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"joystick\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/thumbstick\",\n"
-														   "					\"/user/hand/right/input/thumbstick\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"front_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/trigger/value\",\n"
-														   "					\"/user/hand/right/input/trigger/value\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"side_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/squeeze/click\",\n"
-														   "					\"/user/hand/right/input/squeeze/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"joystick_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/thumbstick/click\",\n"
-														   "					\"/user/hand/right/input/thumbstick/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"haptic\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/output/haptic\",\n"
-														   "					\"/user/hand/right/output/haptic\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "		],\n"
-														   "	},\n"
-														   "	{\n"
-														   "		\"path\": \"/interaction_profiles/oculus/touch_controller\",\n"
-														   "		\"bindings\": [\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"aim_pose\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/aim/pose\",\n"
-														   "					\"/user/hand/right/input/aim/pose\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"grip_pose\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/grip/pose\",\n"
-														   "					\"/user/hand/right/input/grip/pose\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"front_trigger\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/trigger/value\",\n"
-														   "					\"/user/hand/right/input/trigger/value\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"side_trigger\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/squeeze/value\",\n"
-														   "					\"/user/hand/right/input/squeeze/value\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"joystick\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/thumbstick\",\n"
-														   "					\"/user/hand/right/input/thumbstick\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"ax_buttons\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/x/click\",\n"
-														   "					\"/user/hand/right/input/a/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"bym_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/y/click\",\n"
-														   "					\"/user/hand/right/input/b/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"front_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/trigger/value\",\n"
-														   "					\"/user/hand/right/input/trigger/value\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"side_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/squeeze/value\",\n"
-														   "					\"/user/hand/right/input/squeeze/value\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"joystick_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/thumbstick/click\",\n"
-														   "					\"/user/hand/right/input/thumbstick/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"haptic\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/output/haptic\",\n"
-														   "					\"/user/hand/right/output/haptic\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "		],\n"
-														   "	},\n"
-														   "	{\n"
-														   "		\"path\": \"/interaction_profiles/valve/index_controller\",\n"
-														   "		\"bindings\": [\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"aim_pose\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/aim/pose\",\n"
-														   "					\"/user/hand/right/input/aim/pose\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"grip_pose\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/grip/pose\",\n"
-														   "					\"/user/hand/right/input/grip/pose\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"front_trigger\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/trigger/value\",\n"
-														   "					\"/user/hand/right/input/trigger/value\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"side_trigger\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/squeeze/value\",\n"
-														   "					\"/user/hand/right/input/squeeze/value\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"joystick\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/thumbstick\",\n"
-														   "					\"/user/hand/right/input/thumbstick\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"ax_buttons\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/a/click\",\n"
-														   "					\"/user/hand/right/input/a/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"bym_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/b/click\",\n"
-														   "					\"/user/hand/right/input/b/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"front_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/trigger/click\",\n"
-														   "					\"/user/hand/right/input/trigger/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"side_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/squeeze/value\",\n"
-														   "					\"/user/hand/right/input/squeeze/value\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"joystick_button\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/input/thumbstick/click\",\n"
-														   "					\"/user/hand/right/input/thumbstick/click\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "			{\n"
-														   "				\"set\": \"godot\",\n"
-														   "				\"action\": \"haptic\",\n"
-														   "				\"paths\": [\n"
-														   "					\"/user/hand/left/output/haptic\",\n"
-														   "					\"/user/hand/right/output/haptic\"\n"
-														   "				]\n"
-														   "			},\n"
-														   "		],\n"
-														   "	},\n"
-														   "]\n";
+const char *OpenXRApi::default_interaction_profiles_json = R"===(
+[
+	{
+		"path": "/interaction_profiles/khr/simple_controller",
+		"bindings": [
+			{
+				"set": "godot",
+				"action": "aim_pose",
+				"paths": [
+					"/user/hand/left/input/aim/pose",
+					"/user/hand/right/input/aim/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "grip_pose",
+				"paths": [
+					"/user/hand/left/input/grip/pose",
+					"/user/hand/right/input/grip/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "menu_button",
+				"paths": [
+					"/user/hand/left/input/menu/click",
+					"/user/hand/right/input/menu/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "select_button",
+				"paths": [
+					"/user/hand/left/input/select/click",
+					"/user/hand/right/input/select/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "haptic",
+				"paths": [
+					"/user/hand/left/output/haptic",
+					"/user/hand/right/output/haptic"
+				]
+			},
+		],
+	},
+	{
+		"path": "/interaction_profiles/htc/vive_controller",
+		"bindings": [
+			{
+				"set": "godot",
+				"action": "aim_pose",
+				"paths": [
+					"/user/hand/left/input/aim/pose",
+					"/user/hand/right/input/aim/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "grip_pose",
+				"paths": [
+					"/user/hand/left/input/grip/pose",
+					"/user/hand/right/input/grip/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "select_button",
+				"paths": [
+					"/user/hand/left/input/system/click",
+					"/user/hand/right/input/system/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_trigger",
+				"paths": [
+					"/user/hand/left/input/trigger/value",
+					"/user/hand/right/input/trigger/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "side_trigger",
+				"paths": [
+					"/user/hand/left/input/squeeze/click",
+					"/user/hand/right/input/squeeze/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary",
+				"paths": [
+					"/user/hand/left/input/trackpad",
+					"/user/hand/right/input/trackpad"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_button",
+				"paths": [
+					"/user/hand/left/input/trigger/click",
+					"/user/hand/right/input/trigger/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "side_button",
+				"paths": [
+					"/user/hand/left/input/squeeze/click",
+					"/user/hand/right/input/squeeze/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "menu_button",
+				"paths": [
+					"/user/hand/left/input/menu/click",
+					"/user/hand/right/input/menu/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary_button",
+				"paths": [
+					"/user/hand/left/input/trackpad/click",
+					"/user/hand/right/input/trackpad/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary_touch",
+				"paths": [
+					"/user/hand/left/input/trackpad/touch",
+					"/user/hand/right/input/trackpad/touch"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "haptic",
+				"paths": [
+					"/user/hand/left/output/haptic",
+					"/user/hand/right/output/haptic"
+				]
+			},
+		],
+	},
+	{
+		"path": "/interaction_profiles/microsoft/motion_controller",
+		"bindings": [
+			{
+				"set": "godot",
+				"action": "aim_pose",
+				"paths": [
+					"/user/hand/left/input/aim/pose",
+					"/user/hand/right/input/aim/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "grip_pose",
+				"paths": [
+					"/user/hand/left/input/grip/pose",
+					"/user/hand/right/input/grip/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_trigger",
+				"paths": [
+					"/user/hand/left/input/trigger/value",
+					"/user/hand/right/input/trigger/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "side_trigger",
+				"paths": [
+					"/user/hand/left/input/squeeze/click",
+					"/user/hand/right/input/squeeze/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary",
+				"paths": [
+					"/user/hand/left/input/thumbstick",
+					"/user/hand/right/input/thumbstick"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "secondary",
+				"paths": [
+					"/user/hand/left/input/trackpad",
+					"/user/hand/right/input/trackpad"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_button",
+				"paths": [
+					"/user/hand/left/input/trigger/value",
+					"/user/hand/right/input/trigger/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "side_button",
+				"paths": [
+					"/user/hand/left/input/squeeze/click",
+					"/user/hand/right/input/squeeze/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "menu_button",
+				"paths": [
+					"/user/hand/left/input/menu/click",
+					"/user/hand/right/input/menu/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary_button",
+				"paths": [
+					"/user/hand/left/input/thumbstick/click",
+					"/user/hand/right/input/thumbstick/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "secondary_button",
+				"paths": [
+					"/user/hand/left/input/trackpad/click",
+					"/user/hand/right/input/trackpad/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "secondary_touch",
+				"paths": [
+					"/user/hand/left/input/trackpad/touch",
+					"/user/hand/right/input/trackpad/touch"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "haptic",
+				"paths": [
+					"/user/hand/left/output/haptic",
+					"/user/hand/right/output/haptic"
+				]
+			},
+		],
+	},
+	{
+		"path": "/interaction_profiles/oculus/touch_controller",
+		"bindings": [
+			{
+				"set": "godot",
+				"action": "aim_pose",
+				"paths": [
+					"/user/hand/left/input/aim/pose",
+					"/user/hand/right/input/aim/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "grip_pose",
+				"paths": [
+					"/user/hand/left/input/grip/pose",
+					"/user/hand/right/input/grip/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_trigger",
+				"paths": [
+					"/user/hand/left/input/trigger/value",
+					"/user/hand/right/input/trigger/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "side_trigger",
+				"paths": [
+					"/user/hand/left/input/squeeze/value",
+					"/user/hand/right/input/squeeze/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary",
+				"paths": [
+					"/user/hand/left/input/thumbstick",
+					"/user/hand/right/input/thumbstick"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "ax_buttons",
+				"paths": [
+					"/user/hand/left/input/x/click",
+					"/user/hand/right/input/a/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "by_button",
+				"paths": [
+					"/user/hand/left/input/y/click",
+					"/user/hand/right/input/b/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_button",
+				"paths": [
+					"/user/hand/left/input/trigger/value",
+					"/user/hand/right/input/trigger/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "side_button",
+				"paths": [
+					"/user/hand/left/input/squeeze/value",
+					"/user/hand/right/input/squeeze/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "menu_button",
+				"paths": [
+					"/user/hand/left/input/menu/click",
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary_button",
+				"paths": [
+					"/user/hand/left/input/thumbstick/click",
+					"/user/hand/right/input/thumbstick/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary_touch",
+				"paths": [
+					"/user/hand/left/input/thumbstick/touch",
+					"/user/hand/right/input/thumbstick/touch"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "haptic",
+				"paths": [
+					"/user/hand/left/output/haptic",
+					"/user/hand/right/output/haptic"
+				]
+			},
+		],
+	},
+	{
+		"path": "/interaction_profiles/valve/index_controller",
+		"bindings": [
+			{
+				"set": "godot",
+				"action": "aim_pose",
+				"paths": [
+					"/user/hand/left/input/aim/pose",
+					"/user/hand/right/input/aim/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "grip_pose",
+				"paths": [
+					"/user/hand/left/input/grip/pose",
+					"/user/hand/right/input/grip/pose"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_trigger",
+				"paths": [
+					"/user/hand/left/input/trigger/value",
+					"/user/hand/right/input/trigger/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "side_trigger",
+				"paths": [
+					"/user/hand/left/input/squeeze/value",
+					"/user/hand/right/input/squeeze/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary",
+				"paths": [
+					"/user/hand/left/input/thumbstick",
+					"/user/hand/right/input/thumbstick"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "secondary",
+				"paths": [
+					"/user/hand/left/input/trackpad",
+					"/user/hand/right/input/trackpad"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "ax_buttons",
+				"paths": [
+					"/user/hand/left/input/a/click",
+					"/user/hand/right/input/a/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "by_button",
+				"paths": [
+					"/user/hand/left/input/b/click",
+					"/user/hand/right/input/b/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_button",
+				"paths": [
+					"/user/hand/left/input/trigger/click",
+					"/user/hand/right/input/trigger/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "side_button",
+				"paths": [
+					"/user/hand/left/input/squeeze/value",
+					"/user/hand/right/input/squeeze/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "menu_button",
+				"paths": [
+					"/user/hand/left/input/system/click",
+					"/user/hand/right/input/system/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary_button",
+				"paths": [
+					"/user/hand/left/input/thumbstick/click",
+					"/user/hand/right/input/thumbstick/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "secondary_button",
+				"paths": [
+					"/user/hand/left/input/trackpad/force",
+					"/user/hand/right/input/trackpad/force"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary_touch",
+				"paths": [
+					"/user/hand/left/input/thumbstick/touch",
+					"/user/hand/right/input/thumbstick/touch"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "secondary_touch",
+				"paths": [
+					"/user/hand/left/input/trackpad/touch",
+					"/user/hand/right/input/trackpad/touch"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "haptic",
+				"paths": [
+					"/user/hand/left/output/haptic",
+					"/user/hand/right/output/haptic"
+				]
+			}
+		]
+	}
+]
+)===";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Session states
@@ -1727,6 +1989,9 @@ Action *OpenXRApi::get_action(const char *p_name) {
 bool OpenXRApi::parse_action_sets(const godot::String &p_json) {
 	// we'll use Godot's built-in JSON parser, good enough for this :)
 
+	// Just in case clean up any action sets we've currently got loaded, it should already be cleared
+	cleanupActionSets();
+
 	if (instance == XR_NULL_HANDLE) {
 		Godot::print("OpenXR can't parse the action sets before OpenXR is initialised.");
 		return false;
@@ -1760,13 +2025,14 @@ bool OpenXRApi::parse_action_sets(const godot::String &p_json) {
 		// Godot::print("New action set {0} - {1} ({2})", action_set_name, localised_name, priority);
 
 		ActionSet *new_action_set = get_action_set(action_set_name);
-
-		new_action_set = new ActionSet(this, action_set_name, localised_name, priority);
 		if (new_action_set == NULL) {
-			Godot::print("Couldn't create action set {0}", action_set_name);
-			continue;
+			new_action_set = new ActionSet(this, action_set_name, localised_name, priority);
+			if (new_action_set == NULL) {
+				Godot::print("Couldn't create action set {0}", action_set_name);
+				continue;
+			}
+			action_sets.push_back(new_action_set);
 		}
-		action_sets.push_back(new_action_set);
 
 		Array actions = action_set["actions"];
 		for (int a = 0; a < actions.size(); a++) {
@@ -2264,22 +2530,35 @@ void OpenXRApi::update_actions() {
 				// but Godot also checks it so... just let Godot do it
 
 				// Button and axis are hardcoded..
+				// Axis
 				if (default_actions[ACTION_FRONT_TRIGGER].action != NULL) {
 					arvr_api->godot_arvr_set_controller_axis(godot_controller, 2, default_actions[ACTION_FRONT_TRIGGER].action->get_as_float(input_path), false); // 0.0 -> 1.0
 				}
 				if (default_actions[ACTION_SIDE_TRIGGER].action != NULL) {
 					arvr_api->godot_arvr_set_controller_axis(godot_controller, 4, default_actions[ACTION_SIDE_TRIGGER].action->get_as_float(input_path), false); // 0.0 -> 1.0
 				}
-				if (default_actions[ACTION_JOYSTICK].action != NULL) {
-					Vector2 v = default_actions[ACTION_JOYSTICK].action->get_as_vector(input_path);
+				if (default_actions[ACTION_PRIMARY].action != NULL) {
+					Vector2 v = default_actions[ACTION_PRIMARY].action->get_as_vector(input_path);
 					arvr_api->godot_arvr_set_controller_axis(godot_controller, 0, v.x, true); // -1.0 -> 1.0
 					arvr_api->godot_arvr_set_controller_axis(godot_controller, 1, v.y, true); // -1.0 -> 1.0
 				}
+				if (default_actions[ACTION_SECONDARY].action != NULL) {
+					Vector2 v = default_actions[ACTION_SECONDARY].action->get_as_vector(input_path);
+					arvr_api->godot_arvr_set_controller_axis(godot_controller, 6, v.x, true); // -1.0 -> 1.0
+					arvr_api->godot_arvr_set_controller_axis(godot_controller, 7, v.y, true); // -1.0 -> 1.0
+				}
+				// Buttons
 				if (default_actions[ACTION_AX_BUTTON].action != NULL) {
 					arvr_api->godot_arvr_set_controller_button(godot_controller, 7, default_actions[ACTION_AX_BUTTON].action->get_as_bool(input_path));
 				}
-				if (default_actions[ACTION_BYM_BUTTON].action != NULL) {
-					arvr_api->godot_arvr_set_controller_button(godot_controller, 1, default_actions[ACTION_BYM_BUTTON].action->get_as_bool(input_path));
+				if (default_actions[ACTION_BY_BUTTON].action != NULL) {
+					arvr_api->godot_arvr_set_controller_button(godot_controller, 1, default_actions[ACTION_BY_BUTTON].action->get_as_bool(input_path));
+				}
+				if (default_actions[ACTION_MENU_BUTTON].action != NULL) {
+					arvr_api->godot_arvr_set_controller_button(godot_controller, 3, default_actions[ACTION_MENU_BUTTON].action->get_as_bool(input_path));
+				}
+				if (default_actions[ACTION_SELECT_BUTTON].action != NULL) {
+					arvr_api->godot_arvr_set_controller_button(godot_controller, 4, default_actions[ACTION_SELECT_BUTTON].action->get_as_bool(input_path));
 				}
 				if (default_actions[ACTION_FRONT_BUTTON].action != NULL) {
 					arvr_api->godot_arvr_set_controller_button(godot_controller, 15, default_actions[ACTION_FRONT_BUTTON].action->get_as_bool(input_path));
@@ -2287,8 +2566,17 @@ void OpenXRApi::update_actions() {
 				if (default_actions[ACTION_SIDE_BUTTON].action != NULL) {
 					arvr_api->godot_arvr_set_controller_button(godot_controller, 2, default_actions[ACTION_SIDE_BUTTON].action->get_as_bool(input_path));
 				}
-				if (default_actions[ACTION_JOYSTICK_BUTTON].action != NULL) {
-					arvr_api->godot_arvr_set_controller_button(godot_controller, 14, default_actions[ACTION_JOYSTICK_BUTTON].action->get_as_bool(input_path));
+				if (default_actions[ACTION_PRIMARY_BUTTON].action != NULL) {
+					arvr_api->godot_arvr_set_controller_button(godot_controller, 14, default_actions[ACTION_PRIMARY_BUTTON].action->get_as_bool(input_path));
+				}
+				if (default_actions[ACTION_SECONDARY_BUTTON].action != NULL) {
+					arvr_api->godot_arvr_set_controller_button(godot_controller, 13, default_actions[ACTION_SECONDARY_BUTTON].action->get_as_bool(input_path));
+				}
+				if (default_actions[ACTION_PRIMARY_TOUCH].action != NULL) {
+					arvr_api->godot_arvr_set_controller_button(godot_controller, 12, default_actions[ACTION_PRIMARY_TOUCH].action->get_as_bool(input_path));
+				}
+				if (default_actions[ACTION_SECONDARY_TOUCH].action != NULL) {
+					arvr_api->godot_arvr_set_controller_button(godot_controller, 11, default_actions[ACTION_SECONDARY_TOUCH].action->get_as_bool(input_path));
 				}
 
 				if (default_actions[ACTION_HAPTIC].action != NULL) {

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -92,14 +92,20 @@ public:
 		// Analog
 		ACTION_FRONT_TRIGGER, // front trigger (Axis 2)
 		ACTION_SIDE_TRIGGER, // side trigger/grip (Axis 4)
-		ACTION_JOYSTICK, // primary joystick (Axis 0/1)
+		ACTION_PRIMARY, // primary joystick/trackpad/thumbstick (Axis 0/1)
+		ACTION_SECONDARY, // secondary joystick/trackpad/thumbstick (Axis 6/7)
 
 		// Buttons
 		ACTION_AX_BUTTON, // A/X button (button 7)
-		ACTION_BYM_BUTTON, // B/Y/Menu button (button 1)
+		ACTION_BY_BUTTON, // B/Y button (button 1)
+		ACTION_MENU_BUTTON, // Menu button (button 3)
+		ACTION_SELECT_BUTTON, // Menu button (button 4)
 		ACTION_FRONT_BUTTON, // front trigger as button (button 15)
 		ACTION_SIDE_BUTTON, // side trigger/grip as button (button 2)
-		ACTION_JOYSTICK_BUTTON, // Click on joystick (button 14)
+		ACTION_PRIMARY_BUTTON, // Click on primary joystick/trackpad/thumbstick (button 14)
+		ACTION_SECONDARY_BUTTON, // Click on secondary joystick/trackpad/thumbstick (button 13)
+		ACTION_PRIMARY_TOUCH, // Finger is on primary joystick/trackpad/thumbstick (button 12)
+		ACTION_SECONDARY_TOUCH, // Finger is on secondary joystick/trackpad/thumbstick (button 12)
 
 		// Output
 		ACTION_HAPTIC, // Haptic output
@@ -118,12 +124,18 @@ public:
 		{ "grip_pose", XR_ACTION_TYPE_POSE_INPUT, NULL },
 		{ "front_trigger", XR_ACTION_TYPE_FLOAT_INPUT, NULL },
 		{ "side_trigger", XR_ACTION_TYPE_FLOAT_INPUT, NULL },
-		{ "joystick", XR_ACTION_TYPE_VECTOR2F_INPUT, NULL },
+		{ "primary", XR_ACTION_TYPE_VECTOR2F_INPUT, NULL },
+		{ "secondary", XR_ACTION_TYPE_VECTOR2F_INPUT, NULL },
 		{ "ax_buttons", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
-		{ "bym_button", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
+		{ "by_button", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
+		{ "menu_button", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
+		{ "select_button", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
 		{ "front_button", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
 		{ "side_button", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
-		{ "joystick_button", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
+		{ "primary_button", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
+		{ "secondary_button", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
+		{ "primary_touch", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
+		{ "secondary_touch", XR_ACTION_TYPE_BOOLEAN_INPUT, NULL },
 		{ "haptic", XR_ACTION_TYPE_VIBRATION_OUTPUT, NULL },
 	};
 


### PR DESCRIPTION
The current input map in the plugin had a few shortcomings.

**Vive Wand Controller**
First of all, we missed the Vive Wand interaction profile, this has now been added.

**Secondary thumbstick/trackpad**
We only had an input for our joystick that mapped to Axis 0 (x) and 1 (y), none of our other plugins ever supported more. 
Vive Wands only have a trackpad, WMR controllers and index controllers have both a joystick and trackpad.

At face value the obvious choice would be to add a trackpad input however this creates a dilemma for many games. Almost all games I've played, if not all games, don't care whether you use a joystick or trackpad, they care that you have a x,y input with which to drive functionality such as movement while often the secondary input remains unused as the two most popular platforms, Vive and Quest, don't have a secondary input.

If we force the game developer to add extra logic in their games to detect what type of controller is in use and switch between using joystick and trackpads, we're ignoring one of the features that make the action set system so strong.

Instead we've chosen to rename the joystick input to primary, and add a secondary. 

Primary is mapped to Axis 0 and 1 and to Button 14 as before and is bound to:
- the Vive trackpad
- the WMR thumbstick
- the Oculus thumbstick (Rift/Rift S/Quest/Quest 2)
- the Index thumbstick

Secondary is mapped to Axis 6 and 7 and to Button 13 and is bound to:
- unused on the Vive
- the WMR trackpad
- unused on Oculus
- the Index trackpad

**Menu button**
When OpenVR was first introduced Vive wands had a menu button, but no A nor B button, and Oculus Touch controllers had an A/B/X and Y but reserved the menu button, hence button 0 was used for B, Y and menu.

This is no longer a restriction (though the menu button can be reserved and made unavailable).

We're now adding a separate action for the menu button and mapping this to button 3.

**Select button**
Vive wands also have a select button and WMR controllers have a system button (but with a warning it may not be available as its reserved for the system). 

For completeness sake I've added this mapping as well and it maps to button 4.
