### PR TITLE
Copy the `addons/godot-openxr/config/` directory into the `assets` folder when building the aar binary

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,12 +24,6 @@ android {
         }
     }
 
-    sourceSets {
-        main {
-            assets.srcDirs += ['../demo/addons/godot-openxr/config']
-        }
-    }
-
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"
@@ -62,3 +56,20 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlinVersion}"
 }
+
+// When using the aar binary only, the *.gdns and *gdnlib files need to be in the same location
+// relative to the `assets` directory, so we recreate the relative directories and copy them prior
+// to building the aar binary.
+final relativeAddonsConfigDir = "addons/godot-openxr/config/"
+final sourceDir = "../demo/$relativeAddonsConfigDir"
+final targetDir = "src/main/assets/$relativeAddonsConfigDir"
+
+task copyAddonsConfig(type: Copy) {
+    doFirst {
+        delete(targetDir)
+    }
+    from sourceDir
+    into targetDir
+}
+
+preBuild.dependsOn(copyAddonsConfig)

--- a/android/src/main/assets/.gitignore
+++ b/android/src/main/assets/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/android/src/main/java/org/godotengine/plugin/vr/openxr/OpenXRPlugin.kt
+++ b/android/src/main/java/org/godotengine/plugin/vr/openxr/OpenXRPlugin.kt
@@ -59,7 +59,7 @@ class OpenXRPlugin(godot: Godot): GodotPlugin(godot) {
 
   override fun getPluginName() = "OpenXR"
 
-  override fun getPluginGDNativeLibrariesPaths() = setOf("godot_openxr.gdnlib")
+  override fun getPluginGDNativeLibrariesPaths() = setOf("addons/godot-openxr/config/godot_openxr.gdnlib")
 
   override fun onGLSurfaceCreated(gl: GL10, config: EGLConfig) {
     super.onGLSurfaceCreated(gl, config)


### PR DESCRIPTION
This ensures that *gdns paths are still valid for projects only using the aar binary.