### PR TITLE
Include algorithm

### DIFF
--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -10,6 +10,7 @@
 #include "openxr/OpenXRApi.h"
 #include "openxr/include/signals_util.h"
 
+#include <algorithm>
 #include <cmath>
 #include <map>
 


### PR DESCRIPTION
Added an include for algorithm, MSVC doesn't recognize `std::min` if we don't include it.