### PR TITLE
Fix broken link to the hand gdns file

### DIFF
--- a/demo/addons/godot-openxr/scenes/left_hand_nodes.tscn
+++ b/demo/addons/godot-openxr/scenes/left_hand_nodes.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://addons/godot-openxr/scenes/center_ball_material.tres" type="Material" id=1]
-[ext_resource path="res://addons/godot-openxr/OpenXRHand.gdns" type="Script" id=2]
+[ext_resource path="res://addons/godot-openxr/config/OpenXRHand.gdns" type="Script" id=2]
 [ext_resource path="res://addons/godot-openxr/scenes/left_hand_material.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-openxr/scenes/bone_material.tres" type="Material" id=4]
 [ext_resource path="res://addons/godot-openxr/scenes/hand_nodes.gd" type="Script" id=5]

--- a/demo/addons/godot-openxr/scenes/right_hand_nodes.tscn
+++ b/demo/addons/godot-openxr/scenes/right_hand_nodes.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://addons/godot-openxr/scenes/hand_nodes.gd" type="Script" id=2]
 [ext_resource path="res://addons/godot-openxr/scenes/right_hand_material.tres" type="Material" id=3]
 [ext_resource path="res://addons/godot-openxr/scenes/bone_material.tres" type="Material" id=4]
-[ext_resource path="res://addons/godot-openxr/OpenXRHand.gdns" type="Script" id=5]
+[ext_resource path="res://addons/godot-openxr/config/OpenXRHand.gdns" type="Script" id=5]
 
 [sub_resource type="SphereMesh" id=1]
 material = ExtResource( 1 )


### PR DESCRIPTION
When the gdns files were moved to config, we missed editing these two helper scenes. 