### PR TITLE
Move default env into world environment

### DIFF
--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=19 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://Main.gd" type="Script" id=1]
 [ext_resource path="res://Ground.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Table.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/godot-openxr/scenes/first_person_controller_vr.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/godot-openxr/assets/valve_hand_models/textures/vr_glove_color.jpg" type="Texture" id=5]
+[ext_resource path="res://default_env.tres" type="Environment" id=6]
 [ext_resource path="res://addons/godot-openxr/scenes/XRPose.tscn" type="PackedScene" id=7]
 [ext_resource path="res://addons/godot-xr-tools/objects/Viewport_2D_in_3D.tscn" type="PackedScene" id=8]
 [ext_resource path="res://ControllerInfo.tscn" type="PackedScene" id=9]
@@ -34,6 +35,9 @@ height = 0.02
 
 [node name="Main" type="Spatial"]
 script = ExtResource( 1 )
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = ExtResource( 6 )
 
 [node name="DirectionalLight" type="DirectionalLight" parent="."]
 transform = Transform( 0.942296, -0.107937, -0.316905, 0.321394, 0.55667, 0.766045, 0.093727, -0.823692, 0.559238, 0, 100, 0 )

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -69,4 +69,3 @@ Fire={
 quality/driver/driver_name="GLES2"
 vram_compression/import_etc=true
 quality/filters/msaa=1
-environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
Moved environment into a world environment node in the demo.

Godot is getting a little silly when it comes to the default environment often loosing it resulting in a default gray background. 

For consistency moving it into a world environment node so it works all the time.