### PR TITLE
Fixing vulkan rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ compile_commands.json
 # Ignore Gradle build output directory
 android/build
 .cxx
+.project
+.settings
+.classpath
 
 # Ignore intellij configuration files and directories
 .idea

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
             "command": "scons",
             "group": "build",
             "options": {
-                "cwd": "${workspaceFolder}/godot-cpp"
+                "cwd": "${workspaceFolder}/thirdparty/godot-cpp"
             },
             "windows": {
                 "args": [

--- a/src/gdclasses/XRInterfaceOpenXR.cpp
+++ b/src/gdclasses/XRInterfaceOpenXR.cpp
@@ -589,7 +589,6 @@ int64_t XRInterfaceOpenXR::_get_camera_feed_id() const {
 	return 0;
 }
 
-/* BLOCKED by https://github.com/godotengine/godot/pull/51179
 RID XRInterfaceOpenXR::_get_external_color_texture() {
 	if (openxr_api != nullptr) {
 		return openxr_api->get_external_color_texture();
@@ -602,4 +601,3 @@ RID XRInterfaceOpenXR::_get_external_depth_texture() {
 	// TODO we should support this
 	return RID();
 }
-*/

--- a/src/gdclasses/XRInterfaceOpenXR.h
+++ b/src/gdclasses/XRInterfaceOpenXR.h
@@ -109,10 +109,8 @@ public:
 	virtual void _set_anchor_detection_is_enabled(bool enabled) override;
 	virtual int64_t _get_camera_feed_id() const override;
 
-	/* BLOCKED by https://github.com/godotengine/godot/pull/51179
 	virtual RID _get_external_color_texture();
 	virtual RID _get_external_depth_texture();
-	*/
 
 	/* Future feature
 	virtual RID _get_external_vrs_texture(uint64_t p_view);

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -1303,7 +1303,7 @@ bool OpenXRApi::initialiseSession() {
 		VkPhysicalDevice vk_physical_device = (VkPhysicalDevice)rendering_device->get_driver_resource(RenderingDevice::DRIVER_RESOURCE_VULKAN_PHYSICAL_DEVICE, RID(), 0);
 		VkDevice vk_device = (VkDevice)rendering_device->get_driver_resource(RenderingDevice::DRIVER_RESOURCE_VULKAN_DEVICE, RID(), 0);
 		uint32_t vk_queue_family_index = (uint32_t)rendering_device->get_driver_resource(RenderingDevice::DRIVER_RESOURCE_VULKAN_QUEUE_FAMILY_INDEX, RID(), 0);
-		uint32_t vk_queue_index = (uint32_t)rendering_device->get_driver_resource(RenderingDevice::DRIVER_RESOURCE_VULKAN_QUEUE, RID(), 0);
+		uint32_t vk_queue_index = 0; // (uint32_t)rendering_device->get_driver_resource(RenderingDevice::DRIVER_RESOURCE_VULKAN_QUEUE, RID(), 0);
 
 		VkPhysicalDevice xr_physical_device = nullptr;
 
@@ -2527,16 +2527,14 @@ void OpenXRApi::render_openxr(const RID &p_render_target) {
 	if (!frameState.shouldRender || !view_pose_valid) {
 		// external texture support should always be available in Godot 4 once we implement it fully...
 
-		/* TODO uncomment this once we implement external texture support
-			XrSwapchainImageReleaseInfo swapchainImageReleaseInfo = {
-				.type = XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO,
-				.next = nullptr
-			};
-			result = xrReleaseSwapchainImage(swapchain, &swapchainImageReleaseInfo);
-			if (!xr_result(result, "failed to release swapchain image!")) {
-				return;
-			}
-		*/
+		XrSwapchainImageReleaseInfo swapchainImageReleaseInfo = {
+			.type = XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO,
+			.next = nullptr
+		};
+		result = xrReleaseSwapchainImage(swapchain, &swapchainImageReleaseInfo);
+		if (!xr_result(result, "failed to release swapchain image!")) {
+			return;
+		}
 
 		// MS wants these in order..
 		// submit 0 layers when we shouldn't render
@@ -2555,6 +2553,7 @@ void OpenXRApi::render_openxr(const RID &p_render_target) {
 		return;
 	}
 
+	/*
 	if (true) { // remove this once we implement external texture support
 		result = acquire_image();
 		if (!xr_result(result, "failed to acquire swapchain image!")) {
@@ -2567,6 +2566,7 @@ void OpenXRApi::render_openxr(const RID &p_render_target) {
 
 		}
 	}
+	*/
 
 	XrSwapchainImageReleaseInfo swapchainImageReleaseInfo = {
 		.type = XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO,
@@ -2671,7 +2671,7 @@ void OpenXRApi::fill_projection_matrix(int eye, double p_z_near, double p_z_far,
 		return;
 	}
 
-	XrMatrix4x4f_CreateProjectionFov(&matrix, GRAPHICS_OPENGL, views[eye].fov, (float) p_z_near, (float) p_z_far);
+	XrMatrix4x4f_CreateProjectionFov(&matrix, GRAPHICS_VULKAN, views[eye].fov, (float) p_z_near, (float) p_z_far);
 
 	for (int i = 0; i < 16; i++) {
 		p_projection[i] = matrix.m[i];


### PR DESCRIPTION
Most of the work to make Vulkan rendering work is already merged into `4.0-dev` but it currently fails on SteamVR and I haven't tried on any other platform. This PR is just the start of the work to put the final touches on this.

We are currently basing the work on `XR_KHR_vulkan_enable` as our plugin doesn't get a turn until Godot has already setup the entire Vulkan rendering setup. We will look into `XR_KHR_vulkan_enable2` later on but this likely will require serious changes in Godot itself possibly moving OpenXR into the core. Time will tell.

This work requires:
- https://github.com/godotengine/godot/pull/51179