### PR TITLE
Updating initialisation process

### DIFF
--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -1,15 +1,5 @@
 extends Spatial
 
-func _ready():
-	# Start our OpenXR session
-	$FPSController.initialise()
-
-	# Just for testing, output the enabled extensions
-	print("Enabled extensions: " + str($FPSController/Configuration.get_enabled_extensions()))
-	print("Supported refresh rates: " + str($FPSController/Configuration.get_available_refresh_rates()))
-	print("Supported color spaces: " + str($FPSController/Configuration.get_available_color_spaces()))
-	print("Current color space: " + str($FPSController/Configuration.get_color_space()))
-
 func _process(delta):
 	# Test for escape to close application, space to reset our reference frame
 	if (Input.is_key_pressed(KEY_ESCAPE)):
@@ -33,3 +23,14 @@ func _process(delta):
 	# this is a little dirty but we're going to just tie the trigger input of our controllers to their haptic output for testing
 	$FPSController/LeftHandController.rumble = $FPSController/LeftHandController.get_joystick_axis(JOY_VR_ANALOG_TRIGGER)
 	$FPSController/RightHandController.rumble = $FPSController/RightHandController.get_joystick_axis(JOY_VR_ANALOG_TRIGGER)
+
+func _on_FPSController_initialised():
+	# Just for testing, output the enabled extensions
+	print("Enabled extensions: " + str($FPSController/Configuration.get_enabled_extensions()))
+	print("Supported refresh rates: " + str($FPSController/Configuration.get_available_refresh_rates()))
+	print("Supported color spaces: " + str($FPSController/Configuration.get_available_color_spaces()))
+	print("Current color space: " + str($FPSController/Configuration.get_color_space()))
+
+func _on_FPSController_failed_initialisation():
+	# exit our app
+	get_tree().quit()

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -154,6 +154,9 @@ viewport_size = Vector2( 600, 400 )
 scene = ExtResource( 12 )
 collision_layer = 1024
 
+[connection signal="failed_initialisation" from="FPSController" to="." method="_on_FPSController_failed_initialisation"]
+[connection signal="initialised" from="FPSController" to="." method="_on_FPSController_initialised"]
+
 [editable path="FPSController"]
 [editable path="FPSController/LeftHand"]
 [editable path="FPSController/LeftHand/HandModel"]

--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -8,6 +8,7 @@ Changes to the Godot OpenXR asset
 - Update to Oculus OpenXR Mobile SDK v34
 - Added support for Oculus passthrough (Quest support only).
 - Fixed hand tracking support on Oculus Quest devices.
+- Added option to automatically initialise plugin when using the premade scenes.
 
 1.1.0
 -------------------


### PR DESCRIPTION
When this plugin was originally implemented it would often be used alongside of other plugins, for instance using OpenXR for desktop and VrApi for Quest support.

As such the initialisation didn't happen automatically when you added the premade scene to your project. The idea here was that you would only call the initialisation function if you ended up using OpenXR but this does mean things do not work "out of the box".

As OpenXR is now at a stage where it can be used to deploy to all platforms it makes sense to automatically initialise it. To not remove existing logic I've added an export variable you can set in the UI which is set by default. There is an argument to do away with this completely and just initialise on `_ready`, worth a discussion here.

![image](https://user-images.githubusercontent.com/1945449/142816879-6df1220b-74fd-4785-bc88-6f1847040487.png)

I've also added signals to communicate back to the main project whether initialisation succeeded or not so the game can do further initialisation that is required after OpenXR is finished. This also allows you to exit the application on failure.