### PR TITLE
Make passthrough a toggle on first person controller

### DIFF
--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -1,9 +1,11 @@
 extends Spatial
 
 func _ready():
+	# Note that our initialised should have run by now, the _ready on FPController runs first!
 	var screen_instance = $Screen.get_scene_instance()
 	if screen_instance:
 		screen_instance.connect("toggle_bounds", self, "_on_toggle_bounds")
+		screen_instance.set_fp_controller($FPController)
 
 func _on_toggle_bounds():
 	$FPController/ShowBounds.visible = !$FPController/ShowBounds.visible

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -54,6 +54,9 @@ directional_shadow_max_distance = 20.0
 
 [node name="FPController" parent="." instance=ExtResource( 4 )]
 
+[node name="ARVRCamera" parent="FPController" index="1"]
+far = 1000.0
+
 [node name="ShadowHead" type="MeshInstance" parent="FPController/ARVRCamera" index="0"]
 transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, -0.0187781, 0.103895 )
 layers = 524288

--- a/demo/scenes/Screen.gd
+++ b/demo/scenes/Screen.gd
@@ -3,6 +3,14 @@ extends Node2D
 signal toggle_bounds
 
 var count = 0
+var fp_controller : ARVROrigin
+
+func set_fp_controller(p_node : ARVROrigin):
+	fp_controller = p_node
+	if fp_controller and fp_controller.is_passthrough_supported():
+		$TogglePassthrough.disabled = false
+	else:
+		$TogglePassthrough.disabled = true
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -14,3 +22,7 @@ func _on_Button_pressed():
 
 func _on_ToggleBounds_pressed():
 	emit_signal("toggle_bounds")
+
+func _on_TogglePassthrough_pressed():
+	if fp_controller:
+		fp_controller.enable_passthrough = !fp_controller.enable_passthrough

--- a/demo/scenes/Screen.tscn
+++ b/demo/scenes/Screen.tscn
@@ -54,15 +54,30 @@ __meta__ = {
 }
 
 [node name="ToggleBounds" type="Button" parent="."]
-margin_left = 422.073
-margin_top = 15.119
-margin_right = 584.073
-margin_bottom = 53.119
+margin_left = 375.0
+margin_top = 10.0
+margin_right = 595.0
+margin_bottom = 49.119
+rect_min_size = Vector2( 220, 0 )
 custom_fonts/font = ExtResource( 1 )
 text = "Toggle bounds"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="TogglePassthrough" type="Button" parent="."]
+margin_left = 375.0
+margin_top = 55.0
+margin_right = 595.0
+margin_bottom = 93.0
+rect_min_size = Vector2( 220, 0 )
+custom_fonts/font = ExtResource( 1 )
+disabled = true
+text = "Toggle passthrough"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]
 [connection signal="pressed" from="ToggleBounds" to="." method="_on_ToggleBounds_pressed"]
+[connection signal="pressed" from="TogglePassthrough" to="." method="_on_TogglePassthrough_pressed"]


### PR DESCRIPTION
Right now the properly on the first person controller script just auto starts passthrough.

This change makes it a proper toggle with which to turn on/off passthrough.

@m4gr3d is this the correct way to implement this? 