### PR TITLE
haptic pulse duration was given in microseconds, rather than ms

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ Other people who have helped out by submitting fixes, enhancements, etc are:
 - [Aaron Franke](https://github.com/aaronfranke)
 - [Benedikt](https://github.com/beniwtv)
 - [Kim Simmons](https://github.com/Zoomulator)
+- [Tom Beckmann](https://github.com/tom95)

--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -10,6 +10,7 @@ Changes to the Godot OpenXR asset
 - Fixed hand tracking support on Oculus Quest devices.
 - Added option to automatically initialise plugin when using the premade scenes.
 - Added function to retrieve playspace
+- Fixed rumble sending too short durations to controllers
 
 1.1.0
 -------------------

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -2708,9 +2708,9 @@ void OpenXRApi::update_actions() {
 					// Full haptic control will be offered through another object
 					float haptic = arvr_api->godot_arvr_get_controller_rumble(godot_controller);
 					if (haptic > 0.0) {
-						// 17000.0 nanoseconds is slightly more then the duration of one frame if we're outputting at 60fps
+						// 17,000,000.0 nanoseconds (17ms) is slightly more then the duration of one frame if we're outputting at 60fps
 						// so if we sustain our pulse we should be issuing a new pulse before the old one ends
-						default_actions[ACTION_HAPTIC].action->do_haptic_pulse(input_path, 17000.0, XR_FREQUENCY_UNSPECIFIED, haptic);
+						default_actions[ACTION_HAPTIC].action->do_haptic_pulse(input_path, 17.0 * 1000 * 1000, XR_FREQUENCY_UNSPECIFIED, haptic);
 					}
 				}
 			} else if (inputmaps[i].godot_controller != -1) {


### PR DESCRIPTION
Tested only with the Valve Index controllers on windows. Before the change, I only got a barely perceptible vibration, even when `rumble` was set to 1.

After the change, the `rumble` value has a proper effect again for me.