### PR TITLE
Hand tracking needs to be cleaned up on session destroy

### DIFF
--- a/src/openxr/extensions/xr_ext_hand_tracking_extension_wrapper.cpp
+++ b/src/openxr/extensions/xr_ext_hand_tracking_extension_wrapper.cpp
@@ -50,7 +50,7 @@ void XRExtHandTrackingExtensionWrapper::on_state_stopping() {
 	cleanup_hand_tracking();
 }
 
-void XRExtHandTrackingExtensionWrapper::on_instance_destroyed() {
+void XRExtHandTrackingExtensionWrapper::on_session_destroyed() {
 	cleanup();
 }
 

--- a/src/openxr/extensions/xr_ext_hand_tracking_extension_wrapper.h
+++ b/src/openxr/extensions/xr_ext_hand_tracking_extension_wrapper.h
@@ -35,7 +35,7 @@ public:
 
 	void on_state_stopping() override;
 
-	void on_instance_destroyed() override;
+	void on_session_destroyed() override;
 
 	const HandTracker *get_hand_tracker(uint32_t p_hand) const;
 


### PR DESCRIPTION
Hand tracking is created on and bound to a session, so cleaning up on instance results in a crash. It should be cleaned up in `on_session_destroyed`