### PR TITLE
Improve logic for selecting swapchain format to use

### DIFF
--- a/demo/ControllerInfo.gd
+++ b/demo/ControllerInfo.gd
@@ -8,10 +8,8 @@ func _ready():
 	# a little dirty but the parent of the parent of the parent should be the controller.
 	controller = get_node("../../../");
 
-	# we should be able to grab copy of our config
-	configuration = preload("res://addons/godot-openxr/config/OpenXRConfig.gdns")
-	if configuration:
-		configuration = configuration.new()
+	# and just go from there to get our configuration node
+	configuration = controller.get_node("../Configuration")
 
 func _process(_delta : float):
 	if controller:

--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -1,5 +1,13 @@
 extends Spatial
 
+func _ready():
+	var screen_instance = $Screen.get_scene_instance()
+	if screen_instance:
+		screen_instance.connect("toggle_bounds", self, "_on_toggle_bounds")
+
+func _on_toggle_bounds():
+	$FPSController/ShowBounds.visible = !$FPSController/ShowBounds.visible
+
 func _process(delta):
 	# Test for escape to close application, space to reset our reference frame
 	if (Input.is_key_pressed(KEY_ESCAPE)):

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -59,18 +59,15 @@ refresh_rate = 0.0
 transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, -0.0187781, 0.103895 )
 layers = 524288
 mesh = SubResource( 1 )
-material/0 = null
 
 [node name="ShadowHMD" type="MeshInstance" parent="FPController/ARVRCamera" index="1"]
 transform = Transform( -1.62921e-07, 0, 1, 0, 1, 0, -1, 0, -1.62921e-07, 1.44924e-09, 0, 0.00889538 )
 layers = 524288
 mesh = SubResource( 2 )
-material/0 = null
 
 [node name="TestInView" type="MeshInstance" parent="FPController/ARVRCamera" index="2"]
 transform = Transform( 0.981744, -0.0364435, -0.186685, 0, 0.981474, -0.191597, 0.190209, 0.188099, 0.963556, 0.129696, 0.100312, -0.347681 )
 mesh = SubResource( 5 )
-material/0 = null
 
 [node name="LeftHandController" parent="FPController" index="2"]
 visible = true
@@ -114,24 +111,18 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 1, -0.5 )
 [node name="Grip" type="MeshInstance" parent="FPController/Left_grip_pose"]
 transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, 0, 0 )
 mesh = SubResource( 3 )
-material/0 = null
 
 [node name="Right_aim_pose" parent="FPController" instance=ExtResource( 7 )]
 
 [node name="Grip" type="MeshInstance" parent="FPController/Right_aim_pose"]
 transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, 0, 0 )
 mesh = SubResource( 3 )
-material/0 = null
 
 [node name="LeftHand" parent="FPController" instance=ExtResource( 14 )]
 motion_range = 1
 
 [node name="Skeleton" parent="FPController/LeftHand/HandModel/Armature001" index="0"]
-bones/9/bound_children = [  ]
 motion_range = 1
-
-[node name="vr_glove_left_slim" parent="FPController/LeftHand/HandModel/Armature001/Skeleton" index="0"]
-material/0 = null
 
 [node name="IndexTip" parent="FPController/LeftHand/HandModel/Armature001/Skeleton" index="1"]
 transform = Transform( 0.19221, -0.669965, -0.717079, 0.977075, 0.19881, 0.076153, 0.0915428, -0.715277, 0.692819, 0.0345973, 0.0355402, -0.164767 )
@@ -139,18 +130,13 @@ transform = Transform( 0.19221, -0.669965, -0.717079, 0.977075, 0.19881, 0.07615
 [node name="ShowIndexTip" type="MeshInstance" parent="FPController/LeftHand/HandModel/Armature001/Skeleton/IndexTip" index="0"]
 visible = false
 mesh = SubResource( 4 )
-material/0 = null
 
 [node name="RightHand" parent="FPController" instance=ExtResource( 15 )]
 motion_range = 1
 albedo_texture = ExtResource( 5 )
 
 [node name="Skeleton" parent="FPController/RightHand/HandModel/Armature" index="0"]
-bones/9/bound_children = [  ]
 motion_range = 1
-
-[node name="vr_glove_right_slim" parent="FPController/RightHand/HandModel/Armature/Skeleton" index="0"]
-material/0 = null
 
 [node name="IndexTip" parent="FPController/RightHand/HandModel/Armature/Skeleton" index="1"]
 transform = Transform( 0.19221, 0.669966, 0.717078, -0.091543, -0.715277, 0.69282, 0.977075, -0.19881, -0.0761527, -0.0345978, -0.164767, -0.0355401 )
@@ -158,9 +144,9 @@ transform = Transform( 0.19221, 0.669966, 0.717078, -0.091543, -0.715277, 0.6928
 [node name="ShowIndexTip" type="MeshInstance" parent="FPController/RightHand/HandModel/Armature/Skeleton/IndexTip" index="0"]
 visible = false
 mesh = SubResource( 4 )
-material/0 = null
 
 [node name="ShowBounds" parent="FPController" instance=ExtResource( 16 )]
+visible = false
 configuration = NodePath("../Configuration")
 
 [node name="Table" parent="." instance=ExtResource( 3 )]

--- a/demo/Screen.gd
+++ b/demo/Screen.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+signal toggle_bounds
+
 var count = 0
 
 # Called when the node enters the scene tree for the first time.
@@ -9,3 +11,6 @@ func _ready():
 func _on_Button_pressed():
 	count = count + 1
 	$Count.text = "Pressed %d times" % [ count ]
+
+func _on_ToggleBounds_pressed():
+	emit_signal("toggle_bounds")

--- a/demo/Screen.tscn
+++ b/demo/Screen.tscn
@@ -53,4 +53,16 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="ToggleBounds" type="Button" parent="."]
+margin_left = 422.073
+margin_top = 15.119
+margin_right = 584.073
+margin_bottom = 53.119
+custom_fonts/font = ExtResource( 1 )
+text = "Toggle bounds"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]
+[connection signal="pressed" from="ToggleBounds" to="." method="_on_ToggleBounds_pressed"]

--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -10,6 +10,7 @@ Changes to the Godot OpenXR asset
 - Use correct predictive timing for controllers.
 - Renamed `FPSController` node of the first person controller scene to `FPController`.
 - Fixed output range for the trigger and grip values.
+- Improvements to swapchain format selection.
 
 1.1.1
 -------------------

--- a/demo/addons/godot-openxr/scenes/first_person_controller_vr.gd
+++ b/demo/addons/godot-openxr/scenes/first_person_controller_vr.gd
@@ -44,8 +44,7 @@ func initialise() -> bool:
 		# Change our viewport so it is tied to our ARVR interface and renders to our HMD
 		vp.arvr = true
 
-		# Our interface will tell us whether we should keep our render buffer in linear color space
-		vp.keep_3d_linear = $Configuration.keep_3d_linear()
+		# We can't set keep linear yet because we won't know the correct value until after our session has begun.
 
 		# increase our physics engine update speed
 		var refresh_rate = $Configuration.get_refresh_rate()
@@ -91,6 +90,12 @@ func _connect_plugin_signals():
 
 func _on_openxr_session_begun():
 	print("OpenXR session begun")
+
+	var vp : Viewport = _get_xr_viewport()
+	if vp:
+		# Our interface will tell us whether we should keep our render buffer in linear color space
+		vp.keep_3d_linear = $Configuration.keep_3d_linear()
+
 	emit_signal("session_begun")
 
 func _on_openxr_session_ending():

--- a/demo/addons/godot-openxr/scenes/visualise_bounds.gd
+++ b/demo/addons/godot-openxr/scenes/visualise_bounds.gd
@@ -5,7 +5,7 @@ export (NodePath) var configuration
 onready var configuration_node = get_node(configuration) if configuration else null
 
 func _update_bounds():
-	visible = false
+	$CSGPolygon.visible = false
 	if configuration_node:
 		var polygon : PoolVector2Array
 		var bounds = configuration_node.get_play_space()
@@ -21,11 +21,11 @@ func _update_bounds():
 				polygon.push_back(Vector2(bounds[i].x, bounds[i].z))
 
 			$CSGPolygon.polygon = polygon
-			visible = true
+			$CSGPolygon.visible = true
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	visible = false
+	$CSGPolygon.visible = false
 
 	var origin = get_node("..")
 	origin.connect("pose_recentered", self, "_update_bounds")

--- a/src/gdclasses/OpenXRPose.cpp
+++ b/src/gdclasses/OpenXRPose.cpp
@@ -48,6 +48,7 @@ void OpenXRPose::_register_methods() {
 			"/user/hand/left,/user/hand/right,/user/treadmill");
 
 	register_method("is_active", &OpenXRPose::is_active);
+	register_method("get_tracking_confidence", &OpenXRPose::get_tracking_confidence);
 }
 
 OpenXRPose::OpenXRPose() {

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -159,6 +159,11 @@ private:
 		ACTION_SET_FAILED
 	};
 
+	struct RequestedSwapchainFormat {
+		int64_t swapchain_format;
+		bool is_linear;
+	};
+
 	static OpenXRApi *singleton;
 	bool initialised = false;
 	bool running = false;
@@ -183,7 +188,7 @@ private:
 
 	bool is_steamvr = false;
 
-	bool keep_3d_linear = true;
+	bool keep_3d_linear = false;
 #ifdef WIN32
 	XrGraphicsBindingOpenGLWin32KHR graphics_binding_gl;
 	XrSwapchainImageOpenGLKHR **images = NULL;
@@ -267,6 +272,8 @@ private:
 
 	bool parse_action_sets(const godot::String &p_json);
 	bool parse_interaction_profiles(const godot::String &p_json);
+
+	godot::String get_swapchain_format_name(int64_t p_swapchain_format);
 
 public:
 	static OpenXRApi *openxr_get_api();

--- a/src/openxr/actions/actionset.cpp
+++ b/src/openxr/actions/actionset.cpp
@@ -96,7 +96,7 @@ bool ActionSet::attach() {
 		Godot::print_error("Can't attach action set if it has not been created.", __FUNCTION__, __FILE__, __LINE__);
 		return false;
 	}
-	if (xr_api->session == NULL) {
+	if (xr_api->session == XR_NULL_HANDLE) {
 		Godot::print_error("Can't attach action set if there is no session.", __FUNCTION__, __FILE__, __LINE__);
 		return false;
 	}

--- a/src/openxr/include/util.h
+++ b/src/openxr/include/util.h
@@ -41,6 +41,11 @@ using namespace godot;
 // The map should be of type std::map<const char *, PFN_xrVoidFunction*>
 #define LOAD_FUNC_POINTER_IN_MAP(map_name, func_name) map_name[#func_name] = (PFN_xrVoidFunction *)&func_name##_ptr
 
+#define ENUM_TO_STRING_CASE(e) \
+	case e: {                  \
+		return String(#e);     \
+	} break;
+
 static XrResult initialize_function_pointer_map(XrInstance instance, std::map<const char *, PFN_xrVoidFunction *> function_pointer_map) {
 	XrResult result;
 	for (auto const &entry : function_pointer_map) {


### PR DESCRIPTION
We've been having some weird issues with handling colors in the plugin.

The OpenXR specification is clear, if you use an sRGB texture type it is expecting the rendering to be done in sRGB with the hardware converting to linear where needed, if you use any other texture type the rendering is supposed to be done/remain in linear color space.

Godot renders in linear color space with its GLES3 driver, then color corrects and converts the result to sRGB when copying that into the buffers setup by OpenXR. That works fine.
Godot renders in sRGB color space with its GLES2 driver and when no post effects are used this is rendered directly into the buffers setup by OpenXR.

The problem we encounter is that under a true OpenGLES2 context, sRGB is not supported. On desktop we're actually running OpenGL3 but on Android we run OpenGLES2. We solved this originally by switching to GL_RGBA8 buffers and directing the render engine to render in linear color space, with the GLES2 renderer doing an sRGB -> linear conversion in the shader. The problem here is that too much color data is lost in this conversion resulting in banding and poor results.

This PR changes the logic so that sRGB formats are used whenever possible, and attempts to use a R10B10G10A2 buffer with GLES2 on Android. 

still testing if this all works fine
