### PR TITLE
Add API for accessing tracking confidence

### DIFF
--- a/demo/ControllerInfo.gd
+++ b/demo/ControllerInfo.gd
@@ -1,11 +1,17 @@
 extends Node2D
 
 var controller : ARVRController = null;
+var configuration
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# a little dirty but the parent of the parent of the parent should be the controller.
 	controller = get_node("../../../");
+
+	# we should be able to grab copy of our config
+	configuration = preload("res://addons/godot-openxr/config/OpenXRConfig.gdns")
+	if configuration:
+		configuration = configuration.new()
 
 func _process(_delta : float):
 	if controller:
@@ -33,3 +39,14 @@ func _process(_delta : float):
 		$Container/SelectButton/Value.pressed = controller.is_button_pressed(JOY_BUTTON_4)
 		$Container/TriggerButton/Value.pressed = controller.is_button_pressed(JOY_VR_TRIGGER)
 		$Container/SideButton/Value.pressed = controller.is_button_pressed(JOY_VR_GRIP)
+
+		if configuration:
+			var confidence = configuration.get_tracking_confidence(controller.controller_id)
+			if confidence == 0:
+				$Container/Tracking.text = "Not tracking"
+			elif confidence == 1:
+				$Container/Tracking.text = "Low confidence"
+			elif confidence == 2:
+				$Container/Tracking.text = "High confidence"
+			else:
+				$Container/Tracking.text = "Unknown tracking status"

--- a/demo/ControllerInfo.tscn
+++ b/demo/ControllerInfo.tscn
@@ -176,3 +176,10 @@ margin_right = 198.0
 margin_bottom = 32.0
 custom_fonts/font = ExtResource( 2 )
 text = "Side button/Grip"
+
+[node name="Tracking" type="Label" parent="Container"]
+margin_top = 310.0
+margin_right = 500.0
+margin_bottom = 342.0
+custom_fonts/font = ExtResource( 2 )
+text = "Tracking state"

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -56,11 +56,13 @@ refresh_rate = 0.0
 transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, -0.0187781, 0.103895 )
 layers = 524288
 mesh = SubResource( 1 )
+material/0 = null
 
 [node name="ShadowHMD" type="MeshInstance" parent="FPSController/ARVRCamera" index="1"]
 transform = Transform( -1.62921e-07, 0, 1, 0, 1, 0, -1, 0, -1.62921e-07, 1.44924e-09, 0, 0.00889538 )
 layers = 524288
 mesh = SubResource( 2 )
+material/0 = null
 
 [node name="LeftHandController" parent="FPSController" index="2"]
 visible = true
@@ -104,18 +106,24 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 1, -0.5 )
 [node name="Grip" type="MeshInstance" parent="FPSController/Left_grip_pose"]
 transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, 0, 0 )
 mesh = SubResource( 3 )
+material/0 = null
 
 [node name="Right_aim_pose" parent="FPSController" instance=ExtResource( 7 )]
 
 [node name="Grip" type="MeshInstance" parent="FPSController/Right_aim_pose"]
 transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, 0, 0 )
 mesh = SubResource( 3 )
+material/0 = null
 
 [node name="LeftHand" parent="FPSController" instance=ExtResource( 14 )]
 motion_range = 1
 
 [node name="Skeleton" parent="FPSController/LeftHand/HandModel/Armature001" index="0"]
+bones/9/bound_children = [  ]
 motion_range = 1
+
+[node name="vr_glove_left_slim" parent="FPSController/LeftHand/HandModel/Armature001/Skeleton" index="0"]
+material/0 = null
 
 [node name="IndexTip" parent="FPSController/LeftHand/HandModel/Armature001/Skeleton" index="1"]
 transform = Transform( 0.19221, -0.669965, -0.717079, 0.977075, 0.19881, 0.076153, 0.0915428, -0.715277, 0.692819, 0.0345973, 0.0355402, -0.164767 )
@@ -123,13 +131,18 @@ transform = Transform( 0.19221, -0.669965, -0.717079, 0.977075, 0.19881, 0.07615
 [node name="ShowIndexTip" type="MeshInstance" parent="FPSController/LeftHand/HandModel/Armature001/Skeleton/IndexTip" index="0"]
 visible = false
 mesh = SubResource( 4 )
+material/0 = null
 
 [node name="RightHand" parent="FPSController" instance=ExtResource( 15 )]
 motion_range = 1
 albedo_texture = ExtResource( 5 )
 
 [node name="Skeleton" parent="FPSController/RightHand/HandModel/Armature" index="0"]
+bones/9/bound_children = [  ]
 motion_range = 1
+
+[node name="vr_glove_right_slim" parent="FPSController/RightHand/HandModel/Armature/Skeleton" index="0"]
+material/0 = null
 
 [node name="IndexTip" parent="FPSController/RightHand/HandModel/Armature/Skeleton" index="1"]
 transform = Transform( 0.19221, 0.669966, 0.717078, -0.091543, -0.715277, 0.69282, 0.977075, -0.19881, -0.0761527, -0.0345978, -0.164767, -0.0355401 )
@@ -137,6 +150,7 @@ transform = Transform( 0.19221, 0.669966, 0.717078, -0.091543, -0.715277, 0.6928
 [node name="ShowIndexTip" type="MeshInstance" parent="FPSController/RightHand/HandModel/Armature/Skeleton/IndexTip" index="0"]
 visible = false
 mesh = SubResource( 4 )
+material/0 = null
 
 [node name="ShowBounds" parent="FPSController" instance=ExtResource( 16 )]
 configuration = NodePath("../Configuration")

--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -6,6 +6,7 @@ Changes to the Godot OpenXR asset
 - Added interaction profile for the HP Reverb G2 controllers.
 - Removed deprecated `com.samsung.android.vr.application.mode` meta-data tag.
 - Updated repo `README`.
+- Added controller tracking confidence
 
 1.1.1
 -------------------

--- a/src/gdclasses/OpenXRConfig.cpp
+++ b/src/gdclasses/OpenXRConfig.cpp
@@ -34,6 +34,8 @@ void OpenXRConfig::_register_methods() {
 
 	register_method("get_enabled_extensions", &OpenXRConfig::get_enabled_extensions);
 
+	register_method("get_tracking_confidence", &OpenXRConfig::get_tracking_confidence);
+
 	register_method("get_action_sets", &OpenXRConfig::get_action_sets);
 	register_method("set_action_sets", &OpenXRConfig::set_action_sets);
 	register_property<OpenXRConfig, String>("action_sets", &OpenXRConfig::set_action_sets, &OpenXRConfig::get_action_sets, String(OpenXRApi::default_action_sets_json), GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_MULTILINE_TEXT);
@@ -212,6 +214,14 @@ godot::Array OpenXRConfig::get_enabled_extensions() const {
 	} else {
 		return openxr_api->get_enabled_extensions();
 	}
+}
+
+int OpenXRConfig::get_tracking_confidence(const int p_godot_controller) const {
+	int confidence = 0;
+	if (openxr_api) {
+		confidence = int(openxr_api->get_controller_tracking_confidence(p_godot_controller));
+	}
+	return confidence;
 }
 
 String OpenXRConfig::get_action_sets() const {

--- a/src/gdclasses/OpenXRConfig.h
+++ b/src/gdclasses/OpenXRConfig.h
@@ -50,6 +50,8 @@ public:
 
 	godot::Array get_enabled_extensions() const;
 
+	int get_tracking_confidence(const int p_godot_controller) const;
+
 	String get_action_sets() const;
 	void set_action_sets(const String p_action_sets);
 

--- a/src/gdclasses/OpenXRHand.cpp
+++ b/src/gdclasses/OpenXRHand.cpp
@@ -132,7 +132,8 @@ void OpenXRHand::_physics_process(float delta) {
 
 	if (hand_tracker->is_initialised && hand_tracker->locations.isActive) {
 		for (int i = 0; i < XR_HAND_JOINT_COUNT_EXT; i++) {
-			Transform t = openxr_api->transform_from_space_location(hand_tracker->joint_locations[i], ws);
+			Transform t;
+			openxr_api->transform_from_location(hand_tracker->joint_locations[i], ws, t);
 			// store the inverse to make live easier later on
 			inv_transforms[i] = t.inverse();
 

--- a/src/gdclasses/OpenXRPose.cpp
+++ b/src/gdclasses/OpenXRPose.cpp
@@ -135,13 +135,19 @@ void OpenXRPose::_physics_process(float delta) {
 	if (action == "SkeletonBase") {
 		if (path == "/user/hand/left") {
 			const HandTracker *hand_tracker = hand_tracking_wrapper->get_hand_tracker(0);
-			set_transform(reference_frame * openxr_api->transform_from_space_location(hand_tracker->joint_locations[XR_HAND_JOINT_PALM_EXT], ws));
+			Transform t;
+			confidence = openxr_api->transform_from_location(hand_tracker->joint_locations[XR_HAND_JOINT_PALM_EXT], ws, t);
+			set_transform(reference_frame * t);
 		} else if (path == "/user/hand/right") {
 			const HandTracker *hand_tracker = hand_tracking_wrapper->get_hand_tracker(1);
-			set_transform(reference_frame * openxr_api->transform_from_space_location(hand_tracker->joint_locations[XR_HAND_JOINT_PALM_EXT], ws));
+			Transform t;
+			confidence = openxr_api->transform_from_location(hand_tracker->joint_locations[XR_HAND_JOINT_PALM_EXT], ws, t);
+			set_transform(reference_frame * t);
 		}
 	} else if (check_action_and_path()) {
-		set_transform(reference_frame * _action->get_as_pose(_path, ws));
+		Transform t;
+		confidence = _action->get_as_pose(_path, ws, t);
+		set_transform(reference_frame * t);
 	}
 }
 
@@ -195,4 +201,8 @@ void OpenXRPose::set_path(const String p_path) {
 	path = p_path;
 	_path = XR_NULL_PATH;
 	fail_cache = false;
+}
+
+int OpenXRPose::get_tracking_confidence() const {
+	return int(confidence);
 }

--- a/src/gdclasses/OpenXRPose.h
+++ b/src/gdclasses/OpenXRPose.h
@@ -14,6 +14,7 @@ class OpenXRPose : public Spatial {
 
 private:
 	OpenXRApi *openxr_api;
+	TrackingConfidence confidence = TRACKING_CONFIDENCE_NONE;
 	XRExtHandTrackingExtensionWrapper *hand_tracking_wrapper = nullptr;
 	bool invisible_if_inactive = true;
 	String action;
@@ -44,6 +45,8 @@ public:
 
 	String get_path() const;
 	void set_path(const String p_path);
+
+	int get_tracking_confidence() const;
 };
 } // namespace godot
 

--- a/src/gdclasses/OpenXRSkeleton.cpp
+++ b/src/gdclasses/OpenXRSkeleton.cpp
@@ -108,7 +108,7 @@ void OpenXRSkeleton::_physics_process(float delta) {
 	if (hand_tracker->is_initialised && hand_tracker->locations.isActive) {
 		// get our transforms
 		for (int i = 0; i < XR_HAND_JOINT_COUNT_EXT; i++) {
-			transforms[i] = openxr_api->transform_from_space_location(hand_tracker->joint_locations[i], ws);
+			openxr_api->transform_from_location(hand_tracker->joint_locations[i], ws, transforms[i]);
 			inv_transforms[i] = transforms[i].inverse();
 		}
 

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -52,6 +52,12 @@
 // forward declare this
 class OpenXRApi;
 
+enum TrackingConfidence {
+	TRACKING_CONFIDENCE_NONE,
+	TRACKING_CONFIDENCE_LOW,
+	TRACKING_CONFIDENCE_HIGH
+};
+
 #include "openxr/actions/action.h"
 #include "openxr/actions/actionset.h"
 
@@ -72,15 +78,16 @@ public:
 		XrPath toplevel_path;
 		godot_int godot_controller;
 		XrPath active_profile; // note, this can be a profile added in the OpenXR runtime unknown to our default mappings
+		TrackingConfidence tracking_confidence;
 	};
 
 	InputMap inputmaps[USER_INPUT_MAX] = {
-		{ "/user/hand/left", XR_NULL_PATH, -1, XR_NULL_PATH },
-		{ "/user/hand/right", XR_NULL_PATH, -1, XR_NULL_PATH },
+		{ "/user/hand/left", XR_NULL_PATH, -1, XR_NULL_PATH, TRACKING_CONFIDENCE_NONE },
+		{ "/user/hand/right", XR_NULL_PATH, -1, XR_NULL_PATH, TRACKING_CONFIDENCE_NONE },
 		// gamepad is already supported in Godots own joystick handling, head we're using directly
-		// { "/user/foot/left", XR_NULL_PATH, -1, XR_NULL_PATH },
-		// { "/user/foot/right", XR_NULL_PATH, -1, XR_NULL_PATH },
-		// { "/user/treadmill", XR_NULL_PATH, -1, XR_NULL_PATH },
+		// { "/user/foot/left", XR_NULL_PATH, -1, XR_NULL_PATH, TRACKING_CONFIDENCE_NONE },
+		// { "/user/foot/right", XR_NULL_PATH, -1, XR_NULL_PATH, TRACKING_CONFIDENCE_NONE },
+		// { "/user/treadmill", XR_NULL_PATH, -1, XR_NULL_PATH, TRACKING_CONFIDENCE_NONE },
 	};
 
 	// Default actions we support so we can mimic our old ARVRController handling
@@ -341,6 +348,8 @@ public:
 
 	godot::Array get_enabled_extensions() const;
 
+	TrackingConfidence get_controller_tracking_confidence(const int p_godot_controller) const;
+
 	static const char *default_action_sets_json;
 	godot::String get_action_sets_json() const;
 	void set_action_sets_json(const godot::String &p_action_sets_json);
@@ -384,8 +393,8 @@ public:
 	godot::Transform transform_from_pose(const XrPosef &p_pose, float p_world_scale);
 
 	// helper method to get a valid transform from an openxr space location
-	godot::Transform transform_from_space_location(const XrSpaceLocation &p_location, float p_world_scale);
-	godot::Transform transform_from_space_location(const XrHandJointLocationEXT &p_location, float p_world_scale);
+	TrackingConfidence transform_from_location(const XrSpaceLocation &p_location, float p_world_scale, Transform &r_transform);
+	TrackingConfidence transform_from_location(const XrHandJointLocationEXT &p_location, float p_world_scale, Transform &r_transform);
 };
 
 #endif /* !OPENXR_API_H */

--- a/src/openxr/actions/action.h
+++ b/src/openxr/actions/action.h
@@ -39,7 +39,7 @@ public:
 	float get_as_float(const XrPath p_path);
 	godot::Vector2 get_as_vector(const XrPath p_path);
 	bool is_pose_active(const XrPath p_path);
-	godot::Transform get_as_pose(const XrPath p_path, float p_world_scale);
+	TrackingConfidence get_as_pose(const XrPath p_path, float p_world_scale, godot::Transform &r_transform);
 	void do_haptic_pulse(const XrPath p_path, XrDuration p_duration, float p_frequency, float p_amplitude);
 };
 


### PR DESCRIPTION
This PR improves the way we're parsing our location information and uses the `locationFlags` returned to determine how accurate our tracking is.

If `locationFlags` is 0 our confidence will be set to `TRACKING_CONFIDENCE_NONE (0)`.
If our valid bits are set but our tracking bits are not, confidence will be set to `TRACKING_CONFIDENCE_LOW (1)`
If both our set our confidence will be set to `TRACKING_CONFIDENCE_HIGH (2)`

These bits are tracked for both rotation and orientation, if both are valid the both need to be tracked for the confidence to be considered high.

You have access to the confidence directly on the `OpenXRPose` node, for ARVRController nodes we do not expose this so I've added a convenience method to `OpenXRConfig` called `get_tracking_confidence`. It takes the controller id as a parameter (so 1 for left hand, 2 for right hand, same as the ARVRControllers). 