### PR TITLE
Advance predictive timing on tracked items used *next* frame

### DIFF
--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=22 format=2]
 
 [ext_resource path="res://Main.gd" type="Script" id=1]
 [ext_resource path="res://Ground.tscn" type="PackedScene" id=2]
@@ -24,6 +24,9 @@ mid_height = 0.1
 [sub_resource type="CapsuleMesh" id=2]
 radius = 0.03
 mid_height = 0.04
+
+[sub_resource type="CubeMesh" id=5]
+size = Vector3( 0.1, 0.1, 0.1 )
 
 [sub_resource type="CylinderMesh" id=3]
 top_radius = 0.01
@@ -62,6 +65,11 @@ material/0 = null
 transform = Transform( -1.62921e-07, 0, 1, 0, 1, 0, -1, 0, -1.62921e-07, 1.44924e-09, 0, 0.00889538 )
 layers = 524288
 mesh = SubResource( 2 )
+material/0 = null
+
+[node name="TestInView" type="MeshInstance" parent="FPSController/ARVRCamera" index="2"]
+transform = Transform( 0.981744, -0.0364435, -0.186685, 0, 0.981474, -0.191597, 0.190209, 0.188099, 0.963556, 0.129696, 0.100312, -0.347681 )
+mesh = SubResource( 5 )
 material/0 = null
 
 [node name="LeftHandController" parent="FPSController" index="2"]

--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -7,6 +7,7 @@ Changes to the Godot OpenXR asset
 - Removed deprecated `com.samsung.android.vr.application.mode` meta-data tag.
 - Updated repo `README`.
 - Added controller tracking confidence
+- Use correct predictive timing for controllers.
 
 1.1.1
 -------------------

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -311,6 +311,7 @@ public:
 	XrFrameState get_frame_state() { return frameState; }
 	String get_system_name() const { return system_name; }
 	uint32_t get_vendor_id() const { return vendor_id; }
+	XrTime get_next_frame_time() const;
 
 	float get_render_target_size_multiplier() { return render_target_size_multiplier; }
 	bool set_render_target_size_multiplier(float multiplier);

--- a/src/openxr/actions/action.cpp
+++ b/src/openxr/actions/action.cpp
@@ -250,7 +250,8 @@ TrackingConfidence Action::get_as_pose(XrPath p_path, float p_world_scale, Trans
 		location.type = XR_TYPE_SPACE_LOCATION;
 		location.next = NULL;
 
-		XrResult result = xrLocateSpace(toplevel_paths[index].space, xr_api->play_space, xr_api->frameState.predictedDisplayTime, &location);
+		XrTime time = xr_api->get_next_frame_time(); // This data will be used for the next frame we render
+		XrResult result = xrLocateSpace(toplevel_paths[index].space, xr_api->play_space, time, &location);
 		if (!xr_api->xr_result(result, "failed to locate space!")) {
 			return TRACKING_CONFIDENCE_NONE;
 		}

--- a/src/openxr/extensions/xr_ext_hand_tracking_extension_wrapper.cpp
+++ b/src/openxr/extensions/xr_ext_hand_tracking_extension_wrapper.cpp
@@ -194,7 +194,8 @@ void XRExtHandTrackingExtensionWrapper::update_handtracking() {
 		return;
 	}
 
-	const XrTime time = openxr_api->get_frame_state().predictedDisplayTime;
+	const XrTime time = openxr_api->get_next_frame_time(); // This data will be used for the next frame we render
+
 	XrResult result;
 
 	for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
In Godot we update tracking data right before rendering but only the camera position and orientation is immediately used during rendering. It isn't until processing the next frame that all the nodes in Godot get position.

This has the result that any objects that are children of the camera will seem to move as you move your head instead of locked in place, and this has the result that hands seem to lag behind ever so slightly.

OpenXR however is always predicting where elements will be at time of rendering. We have control over this timing and can advance it by one frame when requesting locations.

This PR does so for obtaining the head center (which is requested when we position the camera node), the controller positions and for hand/finger tracking.
When obtaining our view transforms we use the current frames timing.