### PR TITLE
Fix controller float input

### DIFF
--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -9,6 +9,7 @@ Changes to the Godot OpenXR asset
 - Added controller tracking confidence
 - Use correct predictive timing for controllers.
 - Renamed `FPSController` node of the first person controller scene to `FPController`.
+- Fixed output range for the trigger and grip values.
 
 1.1.1
 -------------------

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -2775,10 +2775,10 @@ void OpenXRApi::update_actions() {
 				// Button and axis are hardcoded..
 				// Axis
 				if (default_actions[ACTION_FRONT_TRIGGER].action != NULL) {
-					arvr_api->godot_arvr_set_controller_axis(godot_controller, 2, default_actions[ACTION_FRONT_TRIGGER].action->get_as_float(input_path), false); // 0.0 -> 1.0
+					arvr_api->godot_arvr_set_controller_axis(godot_controller, 2, default_actions[ACTION_FRONT_TRIGGER].action->get_as_float(input_path), true); // 0.0 -> 1.0
 				}
 				if (default_actions[ACTION_SIDE_TRIGGER].action != NULL) {
-					arvr_api->godot_arvr_set_controller_axis(godot_controller, 4, default_actions[ACTION_SIDE_TRIGGER].action->get_as_float(input_path), false); // 0.0 -> 1.0
+					arvr_api->godot_arvr_set_controller_axis(godot_controller, 4, default_actions[ACTION_SIDE_TRIGGER].action->get_as_float(input_path), true); // 0.0 -> 1.0
 				}
 				if (default_actions[ACTION_PRIMARY].action != NULL) {
 					Vector2 v = default_actions[ACTION_PRIMARY].action->get_as_vector(input_path);

--- a/src/openxr/actions/action.cpp
+++ b/src/openxr/actions/action.cpp
@@ -129,6 +129,13 @@ float Action::get_as_float(XrPath p_path) {
 
 		// we should do something with resultState.isActive
 
+		// clamp our value between -1.0 and 1.0, shouldn't be outside of this range but better safe then sorry...
+		if (resultState.currentState < -1.0) {
+			resultState.currentState = -1.0;
+		} else if (resultState.currentState > 1.0) {
+			resultState.currentState = 1.0;
+		}
+
 		return resultState.currentState;
 	}
 }


### PR DESCRIPTION
Fixes #157, as Malcolm correctly found out, when we specify the `p_can_be_negative` parameter as false a range from 0.0 to 1.0 is rescaled to -1.0 to 1.0. 

I have no memory of when and why we did this, it must have been a choice that made sense 4 years ago when this was all first implemented but it gives unexpected behavior.

This PR changes that property to true in the two instances it was false, namely trigger and grip input, making sure the value we pass stays exactly what it is and the expected behavior of this value being between 0.0 and 1.0 is respected.

This is by definition a breaking change but I think most people will have build their logic expecting this value being between 0.0 and 1.0 as is consistent with other plugins. Therefor I feel it is safe to add this in the 1.2 release.

I have also added a clamp because some people were reporting values > 1.0, I've asked for clarification on the OpenXR slack to find out if this is expected behavior and how we can determine the expected range but I am assuming this is a fluke or otherwise incorrect data being received. 