### PR TITLE
Remove simple controller and move oculus touch forward

### DIFF
--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -3,7 +3,7 @@ Changes to the Godot OpenXR asset
 
 1.3.0
 -------------------
-- 
+- Removed standard controller
 
 1.2.0
 -------------------

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -225,7 +225,7 @@ const char *OpenXRApi::default_action_sets_json = R"===(
 const char *OpenXRApi::default_interaction_profiles_json = R"===(
 [
 	{
-		"path": "/interaction_profiles/khr/simple_controller",
+		"path": "/interaction_profiles/oculus/touch_controller",
 		"bindings": [
 			{
 				"set": "godot",
@@ -245,18 +245,105 @@ const char *OpenXRApi::default_interaction_profiles_json = R"===(
 			},
 			{
 				"set": "godot",
-				"action": "menu_button",
+				"action": "front_trigger",
 				"paths": [
-					"/user/hand/left/input/menu/click",
-					"/user/hand/right/input/menu/click"
+					"/user/hand/left/input/trigger/value",
+					"/user/hand/right/input/trigger/value"
 				]
 			},
 			{
 				"set": "godot",
-				"action": "select_button",
+				"action": "side_trigger",
 				"paths": [
-					"/user/hand/left/input/select/click",
-					"/user/hand/right/input/select/click"
+					"/user/hand/left/input/squeeze/value",
+					"/user/hand/right/input/squeeze/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary",
+				"paths": [
+					"/user/hand/left/input/thumbstick",
+					"/user/hand/right/input/thumbstick"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "ax_button",
+				"paths": [
+					"/user/hand/left/input/x/click",
+					"/user/hand/right/input/a/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "by_button",
+				"paths": [
+					"/user/hand/left/input/y/click",
+					"/user/hand/right/input/b/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "ax_touch",
+				"paths": [
+					"/user/hand/left/input/x/touch",
+					"/user/hand/right/input/a/touch"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "by_touch",
+				"paths": [
+					"/user/hand/left/input/y/touch",
+					"/user/hand/right/input/b/touch"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_button",
+				"paths": [
+					"/user/hand/left/input/trigger/value",
+					"/user/hand/right/input/trigger/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "front_touch",
+				"paths": [
+					"/user/hand/left/input/trigger/touch",
+					"/user/hand/right/input/trigger/touch"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "side_button",
+				"paths": [
+					"/user/hand/left/input/squeeze/value",
+					"/user/hand/right/input/squeeze/value"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "menu_button",
+				"paths": [
+					"/user/hand/left/input/menu/click",
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary_button",
+				"paths": [
+					"/user/hand/left/input/thumbstick/click",
+					"/user/hand/right/input/thumbstick/click"
+				]
+			},
+			{
+				"set": "godot",
+				"action": "primary_touch",
+				"paths": [
+					"/user/hand/left/input/thumbstick/touch",
+					"/user/hand/right/input/thumbstick/touch"
 				]
 			},
 			{
@@ -568,138 +655,6 @@ const char *OpenXRApi::default_interaction_profiles_json = R"===(
 				"paths": [
 					"/user/hand/left/input/y/click",
 					"/user/hand/right/input/b/click"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "haptic",
-				"paths": [
-					"/user/hand/left/output/haptic",
-					"/user/hand/right/output/haptic"
-				]
-			},
-		],
-	},
-	{
-		"path": "/interaction_profiles/oculus/touch_controller",
-		"bindings": [
-			{
-				"set": "godot",
-				"action": "aim_pose",
-				"paths": [
-					"/user/hand/left/input/aim/pose",
-					"/user/hand/right/input/aim/pose"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "grip_pose",
-				"paths": [
-					"/user/hand/left/input/grip/pose",
-					"/user/hand/right/input/grip/pose"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "front_trigger",
-				"paths": [
-					"/user/hand/left/input/trigger/value",
-					"/user/hand/right/input/trigger/value"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "side_trigger",
-				"paths": [
-					"/user/hand/left/input/squeeze/value",
-					"/user/hand/right/input/squeeze/value"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "primary",
-				"paths": [
-					"/user/hand/left/input/thumbstick",
-					"/user/hand/right/input/thumbstick"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "ax_button",
-				"paths": [
-					"/user/hand/left/input/x/click",
-					"/user/hand/right/input/a/click"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "by_button",
-				"paths": [
-					"/user/hand/left/input/y/click",
-					"/user/hand/right/input/b/click"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "ax_touch",
-				"paths": [
-					"/user/hand/left/input/x/touch",
-					"/user/hand/right/input/a/touch"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "by_touch",
-				"paths": [
-					"/user/hand/left/input/y/touch",
-					"/user/hand/right/input/b/touch"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "front_button",
-				"paths": [
-					"/user/hand/left/input/trigger/value",
-					"/user/hand/right/input/trigger/value"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "front_touch",
-				"paths": [
-					"/user/hand/left/input/trigger/touch",
-					"/user/hand/right/input/trigger/touch"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "side_button",
-				"paths": [
-					"/user/hand/left/input/squeeze/value",
-					"/user/hand/right/input/squeeze/value"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "menu_button",
-				"paths": [
-					"/user/hand/left/input/menu/click",
-				]
-			},
-			{
-				"set": "godot",
-				"action": "primary_button",
-				"paths": [
-					"/user/hand/left/input/thumbstick/click",
-					"/user/hand/right/input/thumbstick/click"
-				]
-			},
-			{
-				"set": "godot",
-				"action": "primary_touch",
-				"paths": [
-					"/user/hand/left/input/thumbstick/touch",
-					"/user/hand/right/input/thumbstick/touch"
 				]
 			},
 			{


### PR DESCRIPTION
This is a changed as a result of a discussion with Rune, one of the XR engineers at Valve. Seems we're not the only ones with issues here but this change works around it (Unreal has this issue too, Unity doesn't but we think this is because Unity does what we're about to do or something similar).

On SteamVR there is logic that when a controller becomes active that is not defined in the suggested bindings (in this particular test case, a controller for an HTC Cosmos), SteamVR would fall back on the touch controller bindings, and if that doesn't exist, falls back on the simple controller.

More often than not the simple controller was the one being selected, but this definition rarely suffices.

We believe that the most likely cause is that there is a timing issue between Godot (/Unreal) submitting the bindings, and SteamVR consuming them and at the time of processing the controller only the touch definition hasn't been submitted yet.
We can even see this with known controllers as they are bound to the simple controller bindings but then change to a matching binding once that is submitted. Obviously this does not seem to be desired behavior and Valve is looking into whether this is an issue that needs changes on their side, but this PR will provide us with a solution in the meanwhile.

First is that we remove the simple controller definition, there really are very few situations where falling back on this controller definition makes sense, most games won't work with these bindings anyway.
Second is that we make the touch controller the first definition we submit. 