### PR TITLE
Reset frame state before xrWaitTime and validate display period

### DIFF
--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -3171,9 +3171,24 @@ void OpenXRApi::process_openxr() {
 		.type = XR_TYPE_FRAME_WAIT_INFO,
 		.next = nullptr
 	};
+	frameState.type = XR_TYPE_FRAME_STATE;
+	frameState.next = nullptr;
+	frameState.predictedDisplayTime = 0;
+	frameState.predictedDisplayPeriod = 0;
+	frameState.shouldRender = false;
 	result = xrWaitFrame(session, &frameWaitInfo, &frameState);
 	if (!xr_result(result, "xrWaitFrame() was not successful, exiting...")) {
+		// reset just in case
+		frameState.predictedDisplayTime = 0;
+		frameState.predictedDisplayPeriod = 0;
+		frameState.shouldRender = false;
 		return;
+	}
+
+	if (frameState.predictedDisplayPeriod > 500000000) {
+		// display period more then 0.5 seconds? must be wrong data
+		Godot::print("OpenXR resetting invalid display period {0}", frameState.predictedDisplayPeriod);
+		frameState.predictedDisplayPeriod = 0;
 	}
 
 	update_actions();


### PR DESCRIPTION
This works around issue #173. It may be that clearing frame state before xrWaitTime is enough, but in case we still get weird numbers, I'm checking for any display period more then 0.5 seconds and clearing it if we receive that. The value retrieved amounted to something like 16570 hours :)

Seeing this is Quest over airlink the best guess I have is that there is some sort of hickup and we're not getting correct data. 