### PR TITLE
Clean up swapchains properly with xrDestroySwapchain

### DIFF
--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -2153,6 +2153,11 @@ bool OpenXRApi::initialiseSwapChains() {
 
 void OpenXRApi::cleanupSwapChains() {
 	if (swapchains != NULL) {
+		for (uint32_t i = 0; i < view_count; i++) {
+			if (swapchains[i] != XR_NULL_HANDLE) {
+				xrDestroySwapchain(swapchains[i]);
+			}
+		}
 		free(swapchains);
 		swapchains = NULL;
 	}


### PR DESCRIPTION
The [XrSwapchain](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XrSwapchain) handle must be eventually freed via the [xrDestroySwapchain](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#xrDestroySwapchain) function.