### PR TITLE
Fix swapchain release issue

### DIFF
--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -205,6 +205,7 @@ private:
 	uint32_t swapchain_sample_count = 1;
 
 	XrSwapchain *swapchains = NULL;
+	bool *swapchain_acquired = NULL;
 	uint32_t view_count;
 
 	XrCompositionLayerProjection *projectionLayer = NULL;
@@ -269,6 +270,9 @@ private:
 	XrResult acquire_image(int eye);
 	void update_actions();
 	void transform_from_matrix(godot_transform *p_dest, XrMatrix4x4f *matrix, float p_world_scale);
+
+	bool release_swapchain(int eye);
+	void end_frame(uint32_t p_layer_count, const XrCompositionLayerBaseHeader *const *p_layers);
 
 	bool parse_action_sets(const godot::String &p_json);
 	bool parse_interaction_profiles(const godot::String &p_json);


### PR DESCRIPTION
Looking into the issue of the swapchain not releasing properly and locking up the left eye buffer when turning on screen recording on the Quest (2). 

Still investigating this but the change so far ensures we end the frame properly even if there was an issue.
Note that we're also including #207 in this just in case this was an issue with an older version of the SDK. 

Waiting on feedback on the Oculus forum to see if anyone else has encountered this:
https://forums.oculusvr.com/t5/OpenXR-Development/Eye-freezes-when-screen-recording/td-p/963673