### PR TITLE
Add configuration setting for play space type

### DIFF
--- a/src/gdclasses/OpenXRConfig.cpp
+++ b/src/gdclasses/OpenXRConfig.cpp
@@ -27,6 +27,10 @@ void OpenXRConfig::_register_methods() {
 	register_property<OpenXRConfig, int>("color_space", &OpenXRConfig::set_color_space, &OpenXRConfig::get_color_space, 1, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_NOEDITOR);
 	register_method("get_available_color_spaces", &OpenXRConfig::get_available_color_spaces);
 
+	register_method("get_play_space_type", &OpenXRConfig::get_play_space_type);
+	register_method("set_play_space_type", &OpenXRConfig::set_play_space_type);
+	register_property<OpenXRConfig, int>("play_space_type", &OpenXRConfig::set_play_space_type, &OpenXRConfig::get_play_space_type, 2, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_DEFAULT, GODOT_PROPERTY_HINT_ENUM, "View,Local,Stage"); // we don't support XR_REFERENCE_SPACE_TYPE_UNBOUNDED_MSFT and XR_REFERENCE_SPACE_TYPE_COMBINED_EYE_VARJO at this time.
+
 	register_method("get_refresh_rate", &OpenXRConfig::get_refresh_rate);
 	register_method("set_refresh_rate", &OpenXRConfig::set_refresh_rate);
 	register_property<OpenXRConfig, double>("refresh_rate", &OpenXRConfig::set_refresh_rate, &OpenXRConfig::get_refresh_rate, 1, GODOT_METHOD_RPC_MODE_DISABLED, GODOT_PROPERTY_USAGE_NOEDITOR);
@@ -186,6 +190,54 @@ godot::Dictionary OpenXRConfig::get_available_color_spaces() {
 		return color_space_wrapper->get_available_color_spaces();
 	} else {
 		return godot::Dictionary();
+	}
+}
+
+int OpenXRConfig::get_play_space_type() const {
+	if (openxr_api == NULL) {
+		return XR_REFERENCE_SPACE_TYPE_STAGE;
+	} else {
+		switch (openxr_api->get_play_space_type()) {
+			case XR_REFERENCE_SPACE_TYPE_VIEW:
+				return 0;
+			case XR_REFERENCE_SPACE_TYPE_LOCAL:
+				return 1;
+			case XR_REFERENCE_SPACE_TYPE_STAGE:
+				return 2;
+				//case XR_REFERENCE_SPACE_TYPE_UNBOUNDED_MSFT:
+				//	return ??;
+				//case XR_REFERENCE_SPACE_TYPE_COMBINED_EYE_VARJO:
+				//	return ??;
+			default:
+				return 2;
+		}
+	}
+}
+
+void OpenXRConfig::set_play_space_type(const int p_play_space_type) {
+	if (openxr_api == NULL) {
+		Godot::print("OpenXR object wasn't constructed.");
+	} else {
+		switch (p_play_space_type) {
+			case 0: {
+				openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_VIEW);
+			} break;
+			case 2: {
+				openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_LOCAL);
+			} break;
+			case 3: {
+				openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_STAGE);
+			} break;
+				//case ??: {
+				//	openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_UNBOUNDED_MSFT);
+				//} break;
+				//case ??: {
+				//	openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_COMBINED_EYE_VARJO);
+				//} break;
+			default: {
+				openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_STAGE);
+			} break;
+		}
 	}
 }
 

--- a/src/gdclasses/OpenXRConfig.h
+++ b/src/gdclasses/OpenXRConfig.h
@@ -46,6 +46,9 @@ public:
 	void set_color_space(const int p_color_space);
 	godot::Dictionary get_available_color_spaces();
 
+	int get_play_space_type() const;
+	void set_play_space_type(const int p_play_space_type);
+
 	double get_refresh_rate() const;
 	void set_refresh_rate(const double p_refresh_rate);
 	godot::Array get_available_refresh_rates() const;

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -1826,6 +1826,14 @@ bool OpenXRApi::initialiseSession() {
 	return true;
 }
 
+void OpenXRApi::set_play_space_type(XrReferenceSpaceType p_type) {
+	if (is_initialised()) {
+		Godot::print_error("Setting the play space type is only allowed prior to initialization.", __FUNCTION__, __FILE__, __LINE__);
+	} else {
+		play_space_type = p_type;
+	}
+}
+
 bool OpenXRApi::set_render_target_size_multiplier(float multiplier) {
 	if (is_initialised()) {
 		Godot::print_error("Setting the render target size multiplier is only allowed prior to initialization.", __FUNCTION__, __FILE__, __LINE__);

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -320,6 +320,9 @@ public:
 	uint32_t get_vendor_id() const { return vendor_id; }
 	XrTime get_next_frame_time() const;
 
+	XrReferenceSpaceType get_play_space_type() { return play_space_type; }
+	void set_play_space_type(XrReferenceSpaceType p_type);
+
 	float get_render_target_size_multiplier() { return render_target_size_multiplier; }
 	bool set_render_target_size_multiplier(float multiplier);
 


### PR DESCRIPTION
Adds an option to our configuration object to set the play space type between view, local and stage.

See https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#reference-spaces for more information