### PR TITLE
Do not scale basis of transform with world scale!

### DIFF
--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -3804,7 +3804,6 @@ TrackingConfidence OpenXRApi::transform_from_location(const XrSpaceLocation &p_l
 	TrackingConfidence confidence = _transform_from_location(p_location, t);
 	if (confidence != TRACKING_CONFIDENCE_NONE) {
 		// only update if we have tracking data
-		t.basis *= p_world_scale;
 		r_transform = t;
 	}
 	return confidence;
@@ -3815,7 +3814,6 @@ TrackingConfidence OpenXRApi::transform_from_location(const XrHandJointLocationE
 	TrackingConfidence confidence = _transform_from_location(p_location, t);
 	if (confidence != TRACKING_CONFIDENCE_NONE) {
 		// only update if we have tracking data
-		t.basis *= p_world_scale;
 		r_transform = t;
 	}
 	return confidence;


### PR DESCRIPTION
This is potentially a breaking change for people who are using world scale. As this was brought to my attention because it was causing issues for people doing so I think this is a safe revert.

I introduced scaling of the basis in commit 0d2ea910fdb761ea9c28eb51e78e6e6ebc0fa210, which is not what we should do here. 
When using world scale it is nice to apply the scaling to ensure controller meshes are scaled, but this should be applied on the controller mesh, NOT on the ARVRController node. Scaling the controller node has a lot of unwanted side effects as it adversely effects physics and as we may child a lot of things that are not expecting to be scaled (such as our teleport visualization).