### PR TITLE
Mgschwans workaround for failed release of swapchain

### DIFF
--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -10,6 +10,7 @@ Changes to the Godot OpenXR asset
 - Add support for the hand tracking aim state extension.
 - OpenXR updated to 1.0.24
 - Oculus OpenXR mobile SDK version 40 update.
+- Added workaround for swapchain release issue.
 
 1.2.0
 -------------------

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -2967,6 +2967,12 @@ bool OpenXRApi::release_swapchain(int eye) {
 			.next = nullptr
 		};
 		XrResult result = xrReleaseSwapchainImage(swapchains[eye], &swapchainImageReleaseInfo);
+
+		// Workaround for dealing with swapchain not getting released properly after screen recording
+		if (result != XR_SUCCESS) {
+			swapchain_error = true;
+		}
+
 		return xr_result(result, "failed to release swapchain image!");
 	} else {
 		return XR_SUCCESS;
@@ -3676,6 +3682,14 @@ void OpenXRApi::process_openxr() {
 		Godot::print("OpenXR resetting invalid display period {0}", frameState.predictedDisplayPeriod);
 #endif
 		frameState.predictedDisplayPeriod = 0;
+	}
+
+	// Workaround for dealing with swapchain not getting released properly after screen recording
+	if (swapchain_error) {
+		swapchain_error = false;
+		Godot::print("Swapchains need reinitialization");
+		cleanupSwapChains();
+		initialiseSwapChains();
 	}
 
 	update_actions();

--- a/src/openxr/OpenXRApi.h
+++ b/src/openxr/OpenXRApi.h
@@ -167,6 +167,7 @@ private:
 	static OpenXRApi *singleton;
 	bool initialised = false;
 	bool running = false;
+	bool swapchain_error = false;
 	int use_count = 1;
 	godot::OS::VideoDriver video_driver = godot::OS::VIDEO_DRIVER_GLES3;
 


### PR DESCRIPTION
Just isolating the workaround by @mgschwan in #214 for re-initialising the swapchain when it fails to release.

This is a weird issue on Oculus Quest where when screen recording starts, we can no longer release images in the swapchain without a good explanation as to what we're doing incorrectly. 

Once we figure out the proper fix we can revert this PR.