### PR TITLE
Adding idle, synchronized, loss pending and exiting signals

### DIFF
--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -11,6 +11,7 @@ Changes to the Godot OpenXR asset
 - OpenXR updated to 1.0.24
 - Oculus OpenXR mobile SDK version 40 update.
 - Added workaround for swapchain release issue.
+- Added signals for all session state changes.
 
 1.2.0
 -------------------

--- a/demo/addons/godot-openxr/scenes/first_person_controller_vr.gd
+++ b/demo/addons/godot-openxr/scenes/first_person_controller_vr.gd
@@ -7,6 +7,10 @@ signal failed_initialisation
 # Also add signals so we can have other parts of the application react to this.
 signal session_begun
 signal session_ending
+signal session_idle
+signal session_synchronized
+signal session_loss_pending
+signal session_exiting
 signal focused_state
 signal visible_state
 signal pose_recentered
@@ -131,11 +135,16 @@ func _stop_passthrough():
 func _connect_plugin_signals():
 	ARVRServer.connect("openxr_session_begun", self, "_on_openxr_session_begun")
 	ARVRServer.connect("openxr_session_ending", self, "_on_openxr_session_ending")
+	ARVRServer.connect("openxr_session_idle", self, "_on_openxr_session_idle")
+	ARVRServer.connect("openxr_session_synchronized", self, "_on_openxr_session_synchronized")
+	ARVRServer.connect("openxr_session_loss_pending", self, "_on_openxr_session_loss_pending")
+	ARVRServer.connect("openxr_session_exiting", self, "_on_openxr_session_exiting")
 	ARVRServer.connect("openxr_focused_state", self, "_on_openxr_focused_state")
 	ARVRServer.connect("openxr_visible_state", self, "_on_openxr_visible_state")
 	ARVRServer.connect("openxr_pose_recentered", self, "_on_openxr_pose_recentered")
 
 func _on_openxr_session_begun():
+	# This is called on session ready.
 	print("OpenXR session begun")
 
 	var vp : Viewport = _get_xr_viewport()
@@ -146,8 +155,26 @@ func _on_openxr_session_begun():
 	emit_signal("session_begun")
 
 func _on_openxr_session_ending():
+	# This is called on session stopping
+
 	print("OpenXR session ending")
 	emit_signal("session_ending")
+
+func _on_openxr_session_idle():
+	print("OpenXR session idle")
+	emit_signal("session_idle")
+
+func _on_openxr_session_synchronized():
+	print("OpenXR session synchronized")
+	emit_signal("session_synchronized")
+
+func _on_openxr_session_loss_pending():
+	print("OpenXR session loss pending")
+	emit_signal("session_loss_pending")
+
+func _on_openxr_session_exiting():
+	print("OpenXR session exiting")
+	emit_signal("session_exiting")
 
 func _on_openxr_focused_state():
 	print("OpenXR focused state")

--- a/src/openxr/OpenXRApi.cpp
+++ b/src/openxr/OpenXRApi.cpp
@@ -2415,17 +2415,20 @@ void OpenXRApi::on_pause() {
 
 bool OpenXRApi::on_state_idle() {
 #ifdef DEBUG
-	Godot::print("On state idle");
+	Godot::print("OpenXR:On state idle");
 #endif
 	for (XRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_idle();
 	}
+
+	emit_plugin_signal(SIGNAL_SESSION_IDLE);
+
 	return true;
 }
 
 bool OpenXRApi::on_state_ready() {
 #ifdef DEBUG
-	Godot::print("On state ready");
+	Godot::print("OpenXR: On state ready");
 #endif
 	XrSessionBeginInfo sessionBeginInfo = {
 		.type = XR_TYPE_SESSION_BEGIN_INFO,
@@ -2462,17 +2465,20 @@ bool OpenXRApi::on_state_ready() {
 
 bool OpenXRApi::on_state_synchronized() {
 #ifdef DEBUG
-	Godot::print("On state synchronized");
+	Godot::print("OpenXR: On state synchronized");
 #endif
 	for (XRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_synchronized();
 	}
+
+	emit_plugin_signal(SIGNAL_SESSION_SYNCHRONIZED);
+
 	return true;
 }
 
 bool OpenXRApi::on_state_visible() {
 #ifdef DEBUG
-	Godot::print("On state visible");
+	Godot::print("OpenXR: On state visible");
 #endif
 	for (XRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_visible();
@@ -2488,7 +2494,7 @@ bool OpenXRApi::on_state_visible() {
 
 bool OpenXRApi::on_state_focused() {
 #ifdef DEBUG
-	Godot::print("On state focused");
+	Godot::print("OpenXR: On state focused");
 #endif
 	for (XRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_focused();
@@ -2504,7 +2510,7 @@ bool OpenXRApi::on_state_focused() {
 
 bool OpenXRApi::on_state_stopping() {
 #ifdef DEBUG
-	Godot::print("On state stopping");
+	Godot::print("OpenXR: On state stopping");
 #endif
 
 	emit_plugin_signal(SIGNAL_SESSION_ENDING);
@@ -2534,24 +2540,30 @@ bool OpenXRApi::on_state_stopping() {
 
 bool OpenXRApi::on_state_loss_pending() {
 #ifdef DEBUG
-	Godot::print("On state loss pending");
+	Godot::print("OpenXR: On state loss pending");
 #endif
 	for (XRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_loss_pending();
 	}
 	uninitialize();
+
+	emit_plugin_signal(SIGNAL_SESSION_LOSS_PENDING);
+
 	return true;
 }
 
 bool OpenXRApi::on_state_exiting() {
 	// we may want to trigger a signal back to the application to tell it, it should quit.
 #ifdef DEBUG
-	Godot::print("On state exiting");
+	Godot::print("OpenXR: On state exiting");
 #endif
 	for (XRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_exiting();
 	}
 	uninitialize();
+
+	emit_plugin_signal(SIGNAL_SESSION_EXITING);
+
 	return true;
 }
 

--- a/src/openxr/include/signals_util.h
+++ b/src/openxr/include/signals_util.h
@@ -7,6 +7,10 @@ using namespace godot;
 
 static const char *SIGNAL_SESSION_BEGUN = "openxr_session_begun";
 static const char *SIGNAL_SESSION_ENDING = "openxr_session_ending";
+static const char *SIGNAL_SESSION_IDLE = "openxr_session_idle";
+static const char *SIGNAL_SESSION_SYNCHRONIZED = "openxr_session_synchronized";
+static const char *SIGNAL_SESSION_LOSS_PENDING = "openxr_session_loss_pending";
+static const char *SIGNAL_SESSION_EXITING = "openxr_session_exiting";
 static const char *SIGNAL_FOCUSED_STATE = "openxr_focused_state";
 static const char *SIGNAL_VISIBLE_STATE = "openxr_visible_state";
 static const char *SIGNAL_POSE_RECENTERED = "openxr_pose_recentered";
@@ -21,6 +25,10 @@ static void register_plugin_signals() {
 	// Register our signals
 	arvr_server->add_user_signal(SIGNAL_SESSION_BEGUN);
 	arvr_server->add_user_signal(SIGNAL_SESSION_ENDING);
+	arvr_server->add_user_signal(SIGNAL_SESSION_IDLE);
+	arvr_server->add_user_signal(SIGNAL_SESSION_SYNCHRONIZED);
+	arvr_server->add_user_signal(SIGNAL_SESSION_LOSS_PENDING);
+	arvr_server->add_user_signal(SIGNAL_SESSION_EXITING);
 	arvr_server->add_user_signal(SIGNAL_FOCUSED_STATE);
 	arvr_server->add_user_signal(SIGNAL_VISIBLE_STATE);
 	arvr_server->add_user_signal(SIGNAL_POSE_RECENTERED);


### PR DESCRIPTION
Added missing signals on session state changes. This is a continuation of this work in PR #214. I did not add ready as we already have `openxr_session_begun` being triggered on our ready state change and it is thus the same thing.