### PR TITLE
Add enums for clarity and fix incorrect play space type

### DIFF
--- a/demo/addons/godot-openxr/CHANGES.md
+++ b/demo/addons/godot-openxr/CHANGES.md
@@ -12,6 +12,7 @@ Changes to the Godot OpenXR asset
 - Oculus OpenXR mobile SDK version 40 update.
 - Added workaround for swapchain release issue.
 - Added signals for all session state changes.
+- Fix issue with configuring play space.
 
 1.2.0
 -------------------

--- a/src/gdclasses/OpenXRConfig.cpp
+++ b/src/gdclasses/OpenXRConfig.cpp
@@ -113,17 +113,17 @@ int OpenXRConfig::get_view_config_type() const {
 		XrViewConfigurationType config_type = openxr_api->get_view_configuration_type();
 		switch (config_type) {
 			case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO: {
-				return 0;
+				return VIEW_CONFIGURATION_MONO;
 			}; break;
 			case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO: {
-				return 1;
+				return VIEW_CONFIGURATION_STEREO;
 			}; break;
 			/* These are not (yet) supported, adding them in here for future reference
 			case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO: {
-				return 2;
+				return VIEW_CONFIGURATION_QUAD;
 			}; break;
 			case XR_VIEW_CONFIGURATION_TYPE_SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT: {
-				return 3;
+				return VIEW_CONFIGURATION_FPO;
 			}; break;
 			*/
 			default: {
@@ -140,11 +140,12 @@ void OpenXRConfig::set_view_config_type(const int p_config_type) {
 	if (openxr_api == nullptr) {
 		Godot::print("OpenXR object wasn't constructed.");
 	} else {
-		switch (p_config_type) {
-			case 0: {
+		ViewConfigurationType config_type = ViewConfigurationType(p_config_type);
+		switch (config_type) {
+			case VIEW_CONFIGURATION_MONO: {
 				openxr_api->set_view_configuration_type(XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO);
 			}; break;
-			case 1: {
+			case VIEW_CONFIGURATION_STEREO: {
 				openxr_api->set_view_configuration_type(XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO);
 			}; break;
 			default: {
@@ -199,15 +200,15 @@ int OpenXRConfig::get_play_space_type() const {
 	} else {
 		switch (openxr_api->get_play_space_type()) {
 			case XR_REFERENCE_SPACE_TYPE_VIEW:
-				return 0;
+				return PLAY_SPACE_VIEW;
 			case XR_REFERENCE_SPACE_TYPE_LOCAL:
-				return 1;
+				return PLAY_SPACE_LOCAL;
 			case XR_REFERENCE_SPACE_TYPE_STAGE:
-				return 2;
+				return PLAY_SPACE_STAGE;
 				//case XR_REFERENCE_SPACE_TYPE_UNBOUNDED_MSFT:
-				//	return ??;
+				//	return PLAY_SPACE_UNBOUNDED;
 				//case XR_REFERENCE_SPACE_TYPE_COMBINED_EYE_VARJO:
-				//	return ??;
+				//	return PLAY_SPACE_COMBINED_EYE;
 			default:
 				return 2;
 		}
@@ -218,20 +219,21 @@ void OpenXRConfig::set_play_space_type(const int p_play_space_type) {
 	if (openxr_api == nullptr) {
 		Godot::print("OpenXR object wasn't constructed.");
 	} else {
-		switch (p_play_space_type) {
-			case 0: {
+		PlaySpaceType play_space_type = PlaySpaceType(p_play_space_type);
+		switch (play_space_type) {
+			case PLAY_SPACE_VIEW: {
 				openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_VIEW);
 			} break;
-			case 2: {
+			case PLAY_SPACE_LOCAL: {
 				openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_LOCAL);
 			} break;
-			case 3: {
+			case PLAY_SPACE_STAGE: {
 				openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_STAGE);
 			} break;
-				//case ??: {
+				//case PLAY_SPACE_UNBOUNDED: {
 				//	openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_UNBOUNDED_MSFT);
 				//} break;
-				//case ??: {
+				//case PLAY_SPACE_COMBINED_EYE: {
 				//	openxr_api->set_play_space_type(XR_REFERENCE_SPACE_TYPE_COMBINED_EYE_VARJO);
 				//} break;
 			default: {

--- a/src/gdclasses/OpenXRConfig.h
+++ b/src/gdclasses/OpenXRConfig.h
@@ -27,6 +27,26 @@ private:
 	XRExtHandTrackingExtensionWrapper *hand_tracking_wrapper = nullptr;
 
 public:
+	// For Godot we can't have gaps in our enums so we define our own where needed.
+	// Sadly GDNative doesn't have a way to expose these enums.
+
+	enum ViewConfigurationType {
+		VIEW_CONFIGURATION_MONO,
+		VIEW_CONFIGURATION_STEREO,
+		// We don't support these (yet)
+		// VIEW_CONFIGURATION_QUAD,
+		// VIEW_CONFIGURATION_FPO,
+	};
+
+	enum PlaySpaceType {
+		PLAY_SPACE_VIEW,
+		PLAY_SPACE_LOCAL,
+		PLAY_SPACE_STAGE,
+		// We don't support these (yet)
+		// PLAY_SPACE_UNBOUNDED,
+		// PLAY_SPACE_COMBINED_EYE,
+	};
+
 	static void _register_methods();
 
 	void _init();


### PR DESCRIPTION
When exposing properties to Godot using enums, they must be sequential. Some of the enums in OpenXR aren't and we can't use them as such.

GDNative does not allow us to expose enums properly so they can be used in code (GDExtension in Godot 4 can), I have still added enum definitions where this is applicable for clarity and to ensure that our mapping code is more readable and less prone to mistakes.

Fixes #212

Replaces #216