### PR TITLE
Handle missing and accidentally reset OpenXRPose.gdns parameters used in the right hand mesh

### DIFF
--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -50,4 +50,5 @@ func _on_FPController_initialised():
 
 func _on_FPController_failed_initialisation():
 	# exit our app
-	get_tree().quit()
+	#get_tree().quit()
+	print("Failed VR initialization, but not quitting!!!")

--- a/demo/addons/godot-openxr/scenes/hand_mesh.gd
+++ b/demo/addons/godot-openxr/scenes/hand_mesh.gd
@@ -20,9 +20,11 @@ func set_motion_range(value):
 func _update_motion_range():
 	# for some reason not consistantly named between the two hands..
 	if $HandModel.find_node("Armature001"):
-		$HandModel/Armature001/Skeleton.motion_range = motion_range
+		if "motion_range" in $HandModel/Armature001/Skeleton:
+			$HandModel/Armature001/Skeleton.motion_range = motion_range
 	else:
-		$HandModel/Armature/Skeleton.motion_range = motion_range
+		if "motion_range" in $HandModel/Armature/Skeleton:
+			$HandModel/Armature/Skeleton.motion_range = motion_range
 
 func set_albedo_texture(value):
 	albedo_texture = value
@@ -48,6 +50,14 @@ func _ready():
 		material = $HandModel/Armature001/Skeleton/vr_glove_left_slim.mesh.surface_get_material(0)
 	else:
 		material = $HandModel/Armature/Skeleton/vr_glove_right_slim.mesh.surface_get_material(0)
+
+		# repair gdns parameters that may have been reset, see https://github.com/GodotVR/godot_openxr/issues/234 
+		if "path" in $HandModel:
+			print("RESETTING PATH from ", $HandModel.path)
+			$HandModel.path = "/user/hand/right"
+		if "hand" in $HandModel/Armature/Skeleton:
+			print("RESETTING HAND from ", $HandModel/Armature/Skeleton.hand)
+			$HandModel/Armature/Skeleton.hand = 1
 
 	_update_motion_range()
 	_update_albedo_texture()

--- a/demo/scenes/ControllerInfo.gd
+++ b/demo/scenes/ControllerInfo.gd
@@ -38,7 +38,7 @@ func _process(_delta : float):
 		$Container/TriggerButton/Value.pressed = controller.is_button_pressed(JOY_VR_TRIGGER)
 		$Container/SideButton/Value.pressed = controller.is_button_pressed(JOY_VR_GRIP)
 
-		if configuration:
+		if configuration and configuration.has_method("get_tracking_confidence"):
 			var confidence = configuration.get_tracking_confidence(controller.controller_id)
 			if confidence == 0:
 				$Container/Tracking.text = "Not tracking"


### PR DESCRIPTION
This is intended to fix https://github.com/GodotVR/godot_openxr/issues/234

It also sorts out the two instances of gdns parameter accessing which prevent using these nodes in an app on the PC without loading VR, which is sometimes a better place to develop and debug features you don't need to be in a headset to test.
